### PR TITLE
Make aiohttp.ClientSession optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,27 +39,21 @@ Ambient Weather. You can generate both from the Profile page in your
 
 ## Creating a Client
 
-An `aioambient` client starts with an
-[aiohttp](https://aiohttp.readthedocs.io/en/stable/) `ClientSession`:
-
 ```python
 import asyncio
-
-from aiohttp import ClientSession
 
 from aioambient import Client
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-      # YOUR CODE HERE
+  """Rock and roll."""
+      client = Client('<YOUR API KEY>', '<YOUR APPLICATION KEY>')
 
 
 asyncio.get_event_loop().run_until_complete(main())
 ```
 
-Create a client, initialize it, then get to it:
+If you have an existing `aiohttp.ClientSession`, you can use it:
 
 ```python
 import asyncio
@@ -70,12 +64,9 @@ from aioambient import Client
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
+  """Rock and roll."""
     async with ClientSession() as websession:
-      client = Client(
-        '<YOUR API KEY>',
-        '<YOUR APPLICATION KEY>',
-        websession)
+      client = Client('<YOUR API KEY>', '<YOUR APPLICATION KEY>', websession)
 
 
 asyncio.get_event_loop().run_until_complete(main())
@@ -86,28 +77,22 @@ asyncio.get_event_loop().run_until_complete(main())
 ```python
 import asyncio
 
-from aiohttp import ClientSession
-
 from aioambient import Client
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-      client = Client(
-        '<YOUR API KEY>',
-        '<YOUR APPLICATION KEY>',
-        websession)
+  """Rock and roll."""
+    client = Client('<YOUR API KEY>', '<YOUR APPLICATION KEY>')
 
-      # Get all devices in an account:
-      await client.api.get_devices()
+    # Get all devices in an account:
+    await client.api.get_devices()
 
-      # Get all stored readings from a device:
-      await client.api.get_device_details('<DEVICE MAC ADDRESS>')
+    # Get all stored readings from a device:
+    await client.api.get_device_details('<DEVICE MAC ADDRESS>')
 
-      # Get all stored readings from a device (starting at a datetime):
-      await client.api.get_device_details(
-        '<DEVICE MAC ADDRESS>', end_date="2019-01-16")
+    # Get all stored readings from a device (starting at a datetime):
+    await client.api.get_device_details(
+      '<DEVICE MAC ADDRESS>', end_date="2019-01-16")
 
 
 asyncio.get_event_loop().run_until_complete(main())
@@ -121,51 +106,45 @@ Please be aware of Ambient Weather's
 ```python
 import asyncio
 
-from aiohttp import ClientSession
-
 from aioambient import Client
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-      client = Client(
-        '<YOUR API KEY>',
-        '<YOUR APPLICATION KEY>',
-        websession)
+    """Rock and roll."""
+    client = Client( '<YOUR API KEY>', '<YOUR APPLICATION KEY>')
 
-      # Define a method (sync or async) that should be run when the websocket
-      # client connects:
-      def connect_method():
-          """Print a simple "hello" message."""
-          print('Client has connected to the websocket')
-      client.websocket.on_connect(connect_method)
+    # Define a method (sync or async) that should be run when the websocket
+    # client connects:
+    def connect_method():
+        """Print a simple "hello" message."""
+        print('Client has connected to the websocket')
+    client.websocket.on_connect(connect_method)
 
-      # Define a method (sync or async) that should be run upon subscribing to
-      # the Ambient Weather cloud:
-      def subscribed_method(data):
-          """Print the data received upon subscribing."""
-          print('Subscription data received: {0}'.format(data))
-      client.websocket.on_subscribed(subscribed_method)
+    # Define a method (sync or async) that should be run upon subscribing to
+    # the Ambient Weather cloud:
+    def subscribed_method(data):
+        """Print the data received upon subscribing."""
+        print('Subscription data received: {0}'.format(data))
+    client.websocket.on_subscribed(subscribed_method)
 
-      # Define a method (sync or async) that should be run upon receiving data:
-      def data_method(data):
-          """Print the data received."""
-          print('Data received: {0}'.format(data))
-      client.websocket.on_data(data_method)
+    # Define a method (sync or async) that should be run upon receiving data:
+    def data_method(data):
+        """Print the data received."""
+        print('Data received: {0}'.format(data))
+    client.websocket.on_data(data_method)
 
-      # Define a method (sync or async) that should be run when the websocket
-      # client disconnects:
-      def disconnect_method(data):
-          """Print a simple "goodbye" message."""
-          print('Client has disconnected from the websocket')
-      client.websocket.on_disconnect(disconnect_method)
+    # Define a method (sync or async) that should be run when the websocket
+    # client disconnects:
+    def disconnect_method(data):
+        """Print a simple "goodbye" message."""
+        print('Client has disconnected from the websocket')
+    client.websocket.on_disconnect(disconnect_method)
 
-      # Connect to the websocket:
-      await client.websocket.connect()
+    # Connect to the websocket:
+    await client.websocket.connect()
 
-      # At any point, disconnect from the websocket:
-      await client.websocket.disconnect()
+    # At any point, disconnect from the websocket:
+    await client.websocket.disconnect()
 
 
 loop = asyncio.get_event_loop()

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ from aioambient import Client
 
 async def main() -> None:
   """Rock and roll."""
-    async with ClientSession() as websession:
-      client = Client('<YOUR API KEY>', '<YOUR APPLICATION KEY>', websession)
+    async with ClientSession() as session:
+      client = Client('<YOUR API KEY>', '<YOUR APPLICATION KEY>', session)
 
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/aioambient/api.py
+++ b/aioambient/api.py
@@ -21,7 +21,7 @@ class API:
         self._api_key = api_key
         self._api_version = api_version
         self._application_key = application_key
-        self._session = session
+        self._session = session or ClientSession()
 
     async def _request(
             self, method: str, endpoint: str, *, params: dict = None) -> list:

--- a/aioambient/api.py
+++ b/aioambient/api.py
@@ -16,7 +16,7 @@ class API:
 
     def __init__(
             self, application_key: str, api_key: str, api_version: int,
-            session: ClientSession) -> None:
+            session: ClientSession = None) -> None:
         """Initialize."""
         self._api_key = api_key
         self._api_version = api_version

--- a/aioambient/client.py
+++ b/aioambient/client.py
@@ -20,8 +20,8 @@ class Client:  # pylint: disable=too-few-public-methods
             self,
             api_key: str,
             application_key: str,
-            session: ClientSession,
             *,
+            session: ClientSession = None,
             api_version: int = DEFAULT_API_VERSION) -> None:
         """Initialize."""
         self.api = API(application_key, api_key, api_version, session)

--- a/example_rest_api.py
+++ b/example_rest_api.py
@@ -2,38 +2,33 @@
 import asyncio
 import logging
 
-from aiohttp import ClientSession
-
 from aioambient import Client
 from aioambient.errors import AmbientError
 
 _LOGGER = logging.getLogger()
 
-API_KEY = '<YOUR API KEY>'
-APP_KEY = '<YOUR APPLICATION KEY>'
-
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
     logging.basicConfig(level=logging.INFO)
-    async with ClientSession() as session:
-        try:
-            # Create a client:
-            client = Client(API_KEY, APP_KEY, session)
 
-            # Get all devices:
-            devices = await client.api.get_devices()
-            _LOGGER.info('Devices: %s', devices)
+    try:
+        # Create a client:
+        client = Client('<YOUR API KEY>', '<YOUR APPLICATION KEY>')
 
-            for device in devices:
-                # Get info on a specific device (by MAC address):
-                details = await client.api.get_device_details(
-                    device['macAddress'])
-                _LOGGER.info(
-                    'Device Details (%s): %s', device['macAddress'], details)
+        # Get all devices:
+        devices = await client.api.get_devices()
+        _LOGGER.info('Devices: %s', devices)
 
-        except AmbientError as err:
-            _LOGGER.error('There was an error: %s', err)
+        for device in devices:
+            # Get info on a specific device (by MAC address):
+            details = await client.api.get_device_details(
+                device['macAddress'])
+            _LOGGER.info(
+                'Device Details (%s): %s', device['macAddress'], details)
+
+    except AmbientError as err:
+        _LOGGER.error('There was an error: %s', err)
 
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/example_websocket.py
+++ b/example_websocket.py
@@ -2,59 +2,53 @@
 import asyncio
 import logging
 
-from aiohttp import ClientSession
-
 from aioambient import Client
 from aioambient.errors import WebsocketConnectionError, WebsocketError
 
 _LOGGER = logging.getLogger()
 
-API_KEY = '<YOUR API KEY>'
-APP_KEY = '<YOUR APPLICATION KEY>'
-
 
 def print_data(data):
     """Print data as it is received."""
-    print('Data received: ', data)
+    _LOGGER.info('Data received: %s', data)
 
 
 def print_goodbye():
     """Print a simple "goodbye" message."""
-    print('Client has disconnected from the websocket')
+    _LOGGER.info('Client has disconnected from the websocket')
 
 
 def print_hello():
     """Print a simple "hello" message."""
-    print('Client has connected to the websocket')
+    _LOGGER.info('Client has connected to the websocket')
 
 
 async def main() -> None:
     """Run the websocket example."""
-    # logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.INFO)
 
-    async with ClientSession() as session:
-        # Create a client:
-        client = Client(API_KEY, APP_KEY, session)
+    # Create a client:
+    client = Client('<YOUR API KEY>', '<YOUR APPLICATION KEY>')
 
-        client.websocket.on_connect(print_hello)
-        client.websocket.on_data(print_data)
-        client.websocket.on_disconnect(print_goodbye)
-        client.websocket.on_subscribed(print_data)
+    client.websocket.on_connect(print_hello)
+    client.websocket.on_data(print_data)
+    client.websocket.on_disconnect(print_goodbye)
+    client.websocket.on_subscribed(print_data)
 
-        try:
-            await client.websocket.connect()
-        except WebsocketConnectionError as err:
-            print('There was a websocket connection error: {0}'.format(err))
-            return
-        except WebsocketError as err:
-            print('There was a generic websocket error: {0}'.format(err))
-            return
+    try:
+        await client.websocket.connect()
+    except WebsocketConnectionError as err:
+        _LOGGER.error('There was a websocket connection error: %s', err)
+        return
+    except WebsocketError as err:
+        _LOGGER.error('There was a generic websocket error: %s', err)
+        return
 
-        for _ in range(30):
-            print('Simulating some other task occurring...')
-            await asyncio.sleep(5)
+    for _ in range(30):
+        _LOGGER.info('Simulating some other task occurring...')
+        await asyncio.sleep(5)
 
-        await client.websocket.disconnect()
+    await client.websocket.disconnect()
 
 
 loop = asyncio.get_event_loop()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,8 @@ from .fixtures.api import device_details_json, devices_json
 
 
 @pytest.mark.asyncio
-async def test_api_error(aresponses, event_loop, devices_json):
+async def test_api_error(aresponses, devices_json):
+    """Test an API error occurring."""
     aresponses.add(
         "api.ambientweather.net",
         "/v1/devices",
@@ -21,15 +22,15 @@ async def test_api_error(aresponses, event_loop, devices_json):
         aresponses.Response(text="", status=500),
     )
 
-    async with aiohttp.ClientSession(loop=event_loop) as websession:
-        client = Client(TEST_API_KEY, TEST_APP_KEY, websession)
+    client = Client(TEST_API_KEY, TEST_APP_KEY)
 
-        with pytest.raises(RequestError):
-            await client.api.get_devices()
+    with pytest.raises(RequestError):
+        await client.api.get_devices()
 
 
 @pytest.mark.asyncio
-async def test_get_device_details(aresponses, event_loop, device_details_json):
+async def test_get_device_details(aresponses, device_details_json):
+    """Test geting details on a device."""
     aresponses.add(
         "api.ambientweather.net",
         "/v1/devices/{0}".format(TEST_MAC),
@@ -37,16 +38,16 @@ async def test_get_device_details(aresponses, event_loop, device_details_json):
         aresponses.Response(text=json.dumps(device_details_json), status=200),
     )
 
-    async with aiohttp.ClientSession(loop=event_loop) as websession:
-        client = Client(TEST_API_KEY, TEST_APP_KEY, websession)
+    client = Client(TEST_API_KEY, TEST_APP_KEY)
 
-        device_details = await client.api.get_device_details(
-            TEST_MAC, end_date=datetime.datetime(2019, 1, 6))
-        assert len(device_details) == 2
+    device_details = await client.api.get_device_details(
+        TEST_MAC, end_date=datetime.datetime(2019, 1, 6))
+    assert len(device_details) == 2
 
 
 @pytest.mark.asyncio
-async def test_get_devices(aresponses, event_loop, devices_json):
+async def test_get_devices(aresponses, devices_json):
+    """Test geting all devices from an account."""
     aresponses.add(
         "api.ambientweather.net",
         "/v1/devices",
@@ -54,8 +55,7 @@ async def test_get_devices(aresponses, event_loop, devices_json):
         aresponses.Response(text=json.dumps(devices_json), status=200),
     )
 
-    async with aiohttp.ClientSession(loop=event_loop) as websession:
-        client = Client(TEST_API_KEY, TEST_APP_KEY, websession)
+    client = Client(TEST_API_KEY, TEST_APP_KEY)
 
-        devices = await client.api.get_devices()
-        assert len(devices) == 2
+    devices = await client.api.get_devices()
+    assert len(devices) == 2

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -23,84 +23,80 @@ def async_mock(*args, **kwargs):
 
 
 @pytest.mark.asyncio
-async def test_connect_success(event_loop):
+async def test_connect_success():
     """Test connecting to the socket."""
-    async with aiohttp.ClientSession(loop=event_loop) as session:
-        client = Client(TEST_API_KEY, TEST_APP_KEY, session)
-        client.websocket._sio.eio.connect = async_mock()
+    client = Client(TEST_API_KEY, TEST_APP_KEY)
+    client.websocket._sio.eio.connect = async_mock()
 
-        await client.websocket.connect()
-        client.websocket._sio.eio.connect.mock.assert_called_once_with(
-            'https://dash2.ambientweather.net/?api=1&applicationKey={0}'.
-            format(TEST_APP_KEY),
-            engineio_path='socket.io',
-            headers={},
-            transports=['websocket'])
+    await client.websocket.connect()
+    client.websocket._sio.eio.connect.mock.assert_called_once_with(
+        'https://dash2.ambientweather.net/?api=1&applicationKey={0}'.
+        format(TEST_APP_KEY),
+        engineio_path='socket.io',
+        headers={},
+        transports=['websocket'])
 
 
 @pytest.mark.asyncio
-async def test_connect_failure(event_loop):
+async def test_connect_failure():
     """Test connecting to the socket and an exception occurring."""
-    async with aiohttp.ClientSession(loop=event_loop) as session:
-        client = Client(TEST_API_KEY, TEST_APP_KEY, session)
-        client.websocket._sio.eio.connect = async_mock(
-            side_effect=SocketIOError())
+    client = Client(TEST_API_KEY, TEST_APP_KEY)
+    client.websocket._sio.eio.connect = async_mock(
+        side_effect=SocketIOError())
 
-        with pytest.raises(WebsocketConnectionError):
-            await client.websocket.connect()
-
-
-@pytest.mark.asyncio
-async def test_general_failure(event_loop):
-    """Test a generic exception occurring."""
-    async with aiohttp.ClientSession(loop=event_loop) as session:
-        client = Client(TEST_API_KEY, TEST_APP_KEY, session)
-        client.websocket._sio._send_packet = async_mock(
-            side_effect=SocketIOError())
-        client.websocket._sio.eio.connect = async_mock()
-
-        with pytest.raises(WebsocketError):
-            await client.websocket.connect()
-            await client.websocket._sio.emit('test')
-
-
-@pytest.mark.asyncio
-async def test_events(event_loop):
-    """Test all events and handlers."""
-    async with aiohttp.ClientSession(loop=event_loop) as session:
-        client = Client(TEST_API_KEY, TEST_APP_KEY, session)
-        client.websocket._sio.eio._trigger_event = async_mock()
-        client.websocket._sio.eio.connect = async_mock()
-        client.websocket._sio.eio.disconnect = async_mock()
-
-        on_connect = MagicMock()
-        on_data = MagicMock()
-        on_subscribed = MagicMock()
-
-        client.websocket.on_connect(on_connect)
-        client.websocket.on_data(on_data)
-        client.websocket.on_disconnect(on_data)
-        client.websocket.on_subscribed(on_subscribed)
-
+    with pytest.raises(WebsocketConnectionError):
         await client.websocket.connect()
-        client.websocket._sio.eio.connect.mock.assert_called_once_with(
-            'https://dash2.ambientweather.net/?api=1&applicationKey={0}'.
-            format(TEST_APP_KEY),
-            engineio_path='socket.io',
-            headers={},
-            transports=['websocket'])
 
-        await client.websocket._sio._trigger_event('connect', '/', 'my_arg')
-        on_connect.assert_called_once_with('my_arg')
 
-        await client.websocket._sio._trigger_event('data', '/', 'my_arg')
-        on_data.assert_called_once_with('my_arg')
+@pytest.mark.asyncio
+async def test_general_failure():
+    """Test a generic exception occurring."""
+    client = Client(TEST_API_KEY, TEST_APP_KEY)
+    client.websocket._sio._send_packet = async_mock(
+        side_effect=SocketIOError())
+    client.websocket._sio.eio.connect = async_mock()
 
-        await client.websocket._sio._trigger_event('subscribed', '/', 'my_arg')
-        on_subscribed.assert_called_once_with('my_arg')
+    with pytest.raises(WebsocketError):
+        await client.websocket.connect()
+        await client.websocket._sio.emit('test')
 
-        await client.websocket.disconnect()
-        await client.websocket._sio._trigger_event('disconnect', '/')
-        on_subscribed.assert_called_once()
-        client.websocket._sio.eio.disconnect.mock.assert_called_once_with(
-            abort=True)
+
+@pytest.mark.asyncio
+async def test_events():
+    """Test all events and handlers."""
+    client = Client(TEST_API_KEY, TEST_APP_KEY)
+    client.websocket._sio.eio._trigger_event = async_mock()
+    client.websocket._sio.eio.connect = async_mock()
+    client.websocket._sio.eio.disconnect = async_mock()
+
+    on_connect = MagicMock()
+    on_data = MagicMock()
+    on_subscribed = MagicMock()
+
+    client.websocket.on_connect(on_connect)
+    client.websocket.on_data(on_data)
+    client.websocket.on_disconnect(on_data)
+    client.websocket.on_subscribed(on_subscribed)
+
+    await client.websocket.connect()
+    client.websocket._sio.eio.connect.mock.assert_called_once_with(
+        'https://dash2.ambientweather.net/?api=1&applicationKey={0}'.
+        format(TEST_APP_KEY),
+        engineio_path='socket.io',
+        headers={},
+        transports=['websocket'])
+
+    await client.websocket._sio._trigger_event('connect', '/', 'my_arg')
+    on_connect.assert_called_once_with('my_arg')
+
+    await client.websocket._sio._trigger_event('data', '/', 'my_arg')
+    on_data.assert_called_once_with('my_arg')
+
+    await client.websocket._sio._trigger_event('subscribed', '/', 'my_arg')
+    on_subscribed.assert_called_once_with('my_arg')
+
+    await client.websocket.disconnect()
+    await client.websocket._sio._trigger_event('disconnect', '/')
+    on_subscribed.assert_called_once()
+    client.websocket._sio.eio.disconnect.mock.assert_called_once_with(
+        abort=True)


### PR DESCRIPTION
**Describe what the PR does:**

This PR removes the requirement of passing an `aiohttp.ClientSession` into the Client; that is now optional.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
