### PR TITLE
Engineio fix

### DIFF
--- a/aioambient/errors.py
+++ b/aioambient/errors.py
@@ -13,12 +13,6 @@ class RequestError(AmbientError):
     pass
 
 
-class WebsocketConnectionError(AmbientError):
-    """Define an error related to websocket connection errors."""
-
-    pass
-
-
 class WebsocketError(AmbientError):
     """Define an error related to generic websocket errors."""
 

--- a/aioambient/websocket.py
+++ b/aioambient/websocket.py
@@ -24,7 +24,7 @@ class Websocket:
         self._user_connect_handler = None
 
     async def _init_connection(self) -> None:
-        """Perform non-user initialization upon connect."""
+        """Perform automatic initialization upon connecting."""
         try:
             await self._sio.emit('subscribe', {'apiKeys': [self._api_key]})
         except (ConnectionError, SocketIOError) as err:

--- a/aioambient/websocket.py
+++ b/aioambient/websocket.py
@@ -22,20 +22,20 @@ class Websocket:
         self._application_key = application_key
         self._sio = AsyncClient()
         self._user_connect_handler = None
-        
+
     async def _init_connection(self) -> None:
         """Perform non-user initialization upon connect."""
         try:
             await self._sio.emit('subscribe', {'apiKeys': [self._api_key]})
         except (ConnectionError, SocketIOError) as err:
             raise WebsocketError(err) from None
-            
+
         if self._user_connect_handler:
             self._user_connect_handler()
 
     def on_connect(self, target: Union[Awaitable, Callable]) -> None:
         """Define a method/coroutine to be called when connecting."""
-        self._user_connect_handler = target
+        self._user_connect_handler = target  # type: ignore
 
     def on_data(self, target: Union[Awaitable, Callable]) -> None:
         """Define a method/coroutine to be called when data is received."""
@@ -52,7 +52,7 @@ class Websocket:
     async def connect(self) -> None:
         """Connect to the socket."""
         self._sio.on('connect', self._init_connection)
-        
+
         try:
             await self._sio.connect(
                 '{0}/?api={1}&applicationKey={2}'.format(

--- a/aioambient/websocket.py
+++ b/aioambient/websocket.py
@@ -1,11 +1,11 @@
 """Define an object to interact with the Websocket API."""
-# pylint: disable=redefined-builtin
+# pylint: disable=redefined-builtin,unused-argument
 from typing import Awaitable, Callable, Union
 
 from socketio import AsyncClient
 from socketio.exceptions import ConnectionError, SocketIOError
 
-from .errors import WebsocketConnectionError, WebsocketError
+from .errors import WebsocketError
 
 WEBSOCKET_API_BASE = 'https://dash2.ambientweather.net'
 
@@ -25,10 +25,7 @@ class Websocket:
 
     async def _init_connection(self) -> None:
         """Perform automatic initialization upon connecting."""
-        try:
-            await self._sio.emit('subscribe', {'apiKeys': [self._api_key]})
-        except (ConnectionError, SocketIOError) as err:
-            raise WebsocketError(err) from None
+        await self._sio.emit('subscribe', {'apiKeys': [self._api_key]})
 
         if self._user_connect_handler:
             self._user_connect_handler()
@@ -51,16 +48,15 @@ class Websocket:
 
     async def connect(self) -> None:
         """Connect to the socket."""
-        self._sio.on('connect', self._init_connection)
-
         try:
+            self._sio.on('connect', self._init_connection)
             await self._sio.connect(
                 '{0}/?api={1}&applicationKey={2}'.format(
                     WEBSOCKET_API_BASE, self._api_version,
                     self._application_key),
                 transports=['websocket'])
         except (ConnectionError, SocketIOError) as err:
-            raise WebsocketConnectionError(err) from None
+            raise WebsocketError(err) from None
 
     async def disconnect(self) -> None:
         """Disconnect from the socket."""

--- a/aioambient/websocket.py
+++ b/aioambient/websocket.py
@@ -23,7 +23,7 @@ class Websocket:
         self._sio = AsyncClient()
         self._user_connect_handler = None
         
-    def _init_connection(self) -> None:
+    async def _init_connection(self) -> None:
         """Perform non-user initialization upon connect."""
         try:
             await self._sio.emit('subscribe', {'apiKeys': [self._api_key]})

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,9 @@ VERSION = None
 REQUIRED = [  # type: ignore
     'aiodns',
     'aiohttp',
-    'python-socketio[asyncio_client]',
-    'websockets',
+    'python-engineio==3.2.2',
+    'python-socketio[asyncio_client]==3.1.2',
+    'websockets'
 ]
 
 # The rest you shouldn't have to touch too much :)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 from socketio.exceptions import SocketIOError
 
 from aioambient import Client
-from aioambient.errors import WebsocketConnectionError, WebsocketError
+from aioambient.errors import WebsocketError
 
 from tests.const import TEST_API_KEY, TEST_APP_KEY
 
@@ -46,22 +46,8 @@ async def test_connect_failure(event_loop):
         client.websocket._sio.eio.connect = async_mock(
             side_effect=SocketIOError())
 
-        with pytest.raises(WebsocketConnectionError):
-            await client.websocket.connect()
-
-
-@pytest.mark.asyncio
-async def test_general_failure(event_loop):
-    """Test a generic exception occurring."""
-    async with aiohttp.ClientSession(loop=event_loop) as session:
-        client = Client(TEST_API_KEY, TEST_APP_KEY, session)
-        client.websocket._sio._send_packet = async_mock(
-            side_effect=SocketIOError())
-        client.websocket._sio.eio.connect = async_mock()
-
         with pytest.raises(WebsocketError):
             await client.websocket.connect()
-            await client.websocket._sio.emit('test')
 
 
 @pytest.mark.asyncio
@@ -90,17 +76,17 @@ async def test_events(event_loop):
             headers={},
             transports=['websocket'])
 
-        await client.websocket._sio._trigger_event('connect', '/', 'my_arg')
-        on_connect.assert_called_once_with('my_arg')
+        await client.websocket._sio._trigger_event('connect', namespace='/')
+        on_connect.assert_called_once()
 
-        await client.websocket._sio._trigger_event('data', '/', 'my_arg')
-        on_data.assert_called_once_with('my_arg')
+        await client.websocket._sio._trigger_event('data', namespace='/')
+        on_data.assert_called_once()
 
-        await client.websocket._sio._trigger_event('subscribed', '/', 'my_arg')
-        on_subscribed.assert_called_once_with('my_arg')
+        await client.websocket._sio._trigger_event('subscribed', namespace='/')
+        on_subscribed.assert_called()
 
         await client.websocket.disconnect()
-        await client.websocket._sio._trigger_event('disconnect', '/')
+        await client.websocket._sio._trigger_event('disconnect', namespace='/')
         on_subscribed.assert_called_once()
         client.websocket._sio.eio.disconnect.mock.assert_called_once_with(
             abort=True)


### PR DESCRIPTION
**Describe what the PR does:**

This PR updates `python-engineio` to 3.2.2, which fixes socket reconnection issues.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
