### PR TITLE
Bump versions of python-engineio and python-socketio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ VERSION = None
 # What packages are required for this module to be executed?
 REQUIRED = [  # type: ignore
     'aiohttp',
-    'python-engineio==3.3.2',
-    'python-socketio[asyncio_client]==3.1.2',
+    'python-engineio>=3.4.4',
+    'python-socketio[asyncio_client]>=3.1.2',
     'websockets'
 ]
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR adjusts `setup.py` in two ways:

1. `python-engineio` must now be version 3.4.4 _or higher_.
2. `python-socketio` must now be version 3.1.2 _or higher_.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)