### PR TITLE
Add explicit async handler methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,32 +134,60 @@ async def main() -> None:
         '<YOUR APPLICATION KEY>',
         websession)
 
-      # Define a method (sync or async) that should be run when the websocket
-      # client connects:
+      # Define a method that should be fired when the websocket client 
+      # connects:
       def connect_method():
           """Print a simple "hello" message."""
           print('Client has connected to the websocket')
       client.websocket.on_connect(connect_method)
 
-      # Define a method (sync or async) that should be run upon subscribing to
-      # the Ambient Weather cloud:
+      # Alternatively, define a coroutine handler:
+      async def connect_coroutine():
+          """Waits for 3 seconds, then print a simple "hello" message."""
+          await asyncio.sleep(3)
+          print('Client has connected to the websocket')
+      client.websocket.async_on_connect(connect_coroutine)
+
+      # Define a method that should be run upon subscribing to the Ambient 
+      # Weather cloud:
       def subscribed_method(data):
           """Print the data received upon subscribing."""
           print('Subscription data received: {0}'.format(data))
       client.websocket.on_subscribed(subscribed_method)
 
-      # Define a method (sync or async) that should be run upon receiving data:
+      # Alternatively, define a coroutine handler:
+      async def subscribed_coroutine(data):
+          """Waits for 3 seconds, then print the incoming data."""
+          await asyncio.sleep(3)
+          print('Subscription data received: {0}'.format(data))
+      client.websocket.async_on_subscribed(subscribed_coroutine)
+
+      # Define a method that should be run upon receiving data:
       def data_method(data):
           """Print the data received."""
           print('Data received: {0}'.format(data))
       client.websocket.on_data(data_method)
 
-      # Define a method (sync or async) that should be run when the websocket
-      # client disconnects:
+      # Alternatively, define a coroutine handler:
+      async def data_coroutine(data):
+          """Wait for 3 seconds, then print the data received."""
+          await asyncio.sleep(3)
+          print('Data received: {0}'.format(data))
+      client.websocket.async_on_data(data_coroutine)
+
+      # Define a method that should be run when the websocket client 
+      # disconnects:
       def disconnect_method(data):
           """Print a simple "goodbye" message."""
           print('Client has disconnected from the websocket')
       client.websocket.on_disconnect(disconnect_method)
+
+      # Alternatively, define a coroutine handler:
+      async def disconnect_coroutine(data):
+          """Wait for 3 seconds, then print a simple "goodbye" message."""
+          await asyncio.sleep(3)
+          print('Client has disconnected from the websocket')
+      client.websocket.async_on_disconnect(disconnect_coroutine)
 
       # Connect to the websocket:
       await client.websocket.connect()

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -22,12 +22,15 @@ def async_mock(*args, **kwargs):
     return mock_coro
 
 
-@pytest.mark.asyncio
-async def test_connect_success(event_loop):
-    """Test connecting to the socket."""
+async def test_connect_async_success(event_loop):
+    """Test connecting to the socket with an async handler."""
     async with aiohttp.ClientSession(loop=event_loop) as session:
         client = Client(TEST_API_KEY, TEST_APP_KEY, session)
+        client.websocket._sio.eio._trigger_event = async_mock()
         client.websocket._sio.eio.connect = async_mock()
+
+        on_connect = async_mock()
+        client.websocket.async_on_connect(on_connect)
 
         await client.websocket.connect()
         client.websocket._sio.eio.connect.mock.assert_called_once_with(
@@ -37,8 +40,32 @@ async def test_connect_success(event_loop):
             headers={},
             transports=['websocket'])
 
+        await client.websocket._sio._trigger_event('connect', namespace='/')
+        on_connect.mock.assert_called_once()
 
-@pytest.mark.asyncio
+
+async def test_connect_sync_success(event_loop):
+    """Test connecting to the socket with a sync handler."""
+    async with aiohttp.ClientSession(loop=event_loop) as session:
+        client = Client(TEST_API_KEY, TEST_APP_KEY, session)
+        client.websocket._sio.eio._trigger_event = async_mock()
+        client.websocket._sio.eio.connect = async_mock()
+
+        on_connect = MagicMock()
+        client.websocket.on_connect(on_connect)
+
+        await client.websocket.connect()
+        client.websocket._sio.eio.connect.mock.assert_called_once_with(
+            'https://dash2.ambientweather.net/?api=1&applicationKey={0}'.
+            format(TEST_APP_KEY),
+            engineio_path='socket.io',
+            headers={},
+            transports=['websocket'])
+
+        await client.websocket._sio._trigger_event('connect', namespace='/')
+        on_connect.assert_called_once()
+
+
 async def test_connect_failure(event_loop):
     """Test connecting to the socket and an exception occurring."""
     async with aiohttp.ClientSession(loop=event_loop) as session:
@@ -50,9 +77,8 @@ async def test_connect_failure(event_loop):
             await client.websocket.connect()
 
 
-@pytest.mark.asyncio
-async def test_events(event_loop):
-    """Test all events and handlers."""
+async def async_test_events(event_loop):
+    """Test all events and async_handlers."""
     async with aiohttp.ClientSession(loop=event_loop) as session:
         client = Client(TEST_API_KEY, TEST_APP_KEY, session)
         client.websocket._sio.eio._trigger_event = async_mock()
@@ -88,5 +114,46 @@ async def test_events(event_loop):
         await client.websocket.disconnect()
         await client.websocket._sio._trigger_event('disconnect', namespace='/')
         on_subscribed.assert_called_once()
+        client.websocket._sio.eio.disconnect.mock.assert_called_once_with(
+            abort=True)
+
+
+async def test_events(event_loop):
+    """Test all events and handlers."""
+    async with aiohttp.ClientSession(loop=event_loop) as session:
+        client = Client(TEST_API_KEY, TEST_APP_KEY, session)
+        client.websocket._sio.eio._trigger_event = async_mock()
+        client.websocket._sio.eio.connect = async_mock()
+        client.websocket._sio.eio.disconnect = async_mock()
+
+        on_connect = async_mock()
+        on_data = async_mock()
+        on_subscribed = async_mock()
+
+        client.websocket.async_on_connect(on_connect)
+        client.websocket.async_on_data(on_data)
+        client.websocket.async_on_disconnect(on_data)
+        client.websocket.async_on_subscribed(on_subscribed)
+
+        await client.websocket.connect()
+        client.websocket._sio.eio.connect.mock.assert_called_once_with(
+            'https://dash2.ambientweather.net/?api=1&applicationKey={0}'.
+            format(TEST_APP_KEY),
+            engineio_path='socket.io',
+            headers={},
+            transports=['websocket'])
+
+        await client.websocket._sio._trigger_event('connect', namespace='/')
+        on_connect.mock.assert_called_once()
+
+        await client.websocket._sio._trigger_event('data', namespace='/')
+        on_data.mock.assert_called_once()
+
+        await client.websocket._sio._trigger_event('subscribed', namespace='/')
+        on_subscribed.mock.assert_called()
+
+        await client.websocket.disconnect()
+        await client.websocket._sio._trigger_event('disconnect', namespace='/')
+        on_subscribed.mock.assert_called_once()
         client.websocket._sio.eio.disconnect.mock.assert_called_once_with(
             abort=True)


### PR DESCRIPTION
**Describe what the PR does:**

Previously, the websocket API used four handler registration methods for all scenarios, regardless of whether the handler was a method or a coroutine:

```
websocket.on_connect
websocket.on_data
websocket.on_disconnect
websocket.on_subscribed
```

I don't like this, as it's not clear to the implementer of `aioambient` whether a method is registering a method or a coroutine. This PR makes that more explicit:

```
websocket.async_on_connect
websocket.on_connect
websocket.async_on_data
websocket.on_data
websocket.on_disconnect
websocket.async_on_disconnect
websocket.on_subscribed
websocket.async_on_subscribed
```

Additionally, this PR fixes a bug where `on_connect` would fail to await a registered coroutine.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
