### PR TITLE
Cancel connect handlers appropriately

### DIFF
--- a/aioambient/websocket.py
+++ b/aioambient/websocket.py
@@ -36,9 +36,11 @@ class Websocket:
     def async_on_connect(self, target: Awaitable) -> None:
         """Define a coroutine to be called when connecting."""
         self._async_user_connect_handler = target  # type: ignore
+        self._user_connect_handler = None
 
     def on_connect(self, target: Union[Awaitable, Callable]) -> None:
         """Define a method to be called when connecting."""
+        self._async_user_connect_handler = None
         self._user_connect_handler = target  # type: ignore
 
     def async_on_data(self, target: Awaitable) -> None:


### PR DESCRIPTION
**Describe what the PR does:**

https://github.com/bachya/aioambient/pull/9 added the ability to register either a sync or an async handler for `on_connect`. However, if the user were to call `on_connect`, then later call `async_on_connect` (or vice versa), handlers would exist for _both_ methods. This PR cancels the opposite handler when registering a new one.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
