### PR TITLE
Bump python-engineio to 3.8.1 and python-socketio to 4.1.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ tox = "*"
 twine = "*"
 
 [packages]
-"python-socketio[asyncio_client]" = ">=3.1.2"
+"python-socketio[asyncio_client]" = ">=4.1.0"
 aiohttp = "*"
-python-engineio = ">=3.5.1"
+python-engineio = ">=3.8.1"
 websockets = "*"

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ VERSION = None
 # What packages are required for this module to be executed?
 REQUIRED = [  # type: ignore
     'aiohttp',
-    'python-engineio>=3.5.1',
-    'python-socketio[asyncio_client]>=3.1.2',
+    'python-engineio>=3.8.1',
+    'python-socketio[asyncio_client]>=4.1.0',
     'websockets'
 ]
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR bumps `python-engineio` to 3.8.1 and `python-socketio` to 4.1.0. Principally, this solves various reconnection errors.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)