### PR TITLE
Switch to f-strings (and remove support for Python 3.5.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,8 @@ pip install aioambient
 
 `aioambient` is currently supported on:
 
-* Python 3.5
 * Python 3.6
 * Python 3.7
-
-However, running the test suite currently requires Python 3.6 or higher; tests
-run on Python 3.5 will fail.
 
 # API and Application Keys
 
@@ -72,10 +68,18 @@ from aioambient import Client
 async def main() -> None:
     """Create the aiohttp session and run the example."""
     async with ClientSession() as websession:
-      client = Client(
-        '<YOUR API KEY>',
-        '<YOUR APPLICATION KEY>',
-        websession)
+        client = Client("<YOUR API KEY>", "<YOUR APPLICATION KEY>", websession)
+
+        # Get all devices in an account:
+        await client.api.get_devices()
+
+        # Get all stored readings from a device:
+        await client.api.get_device_details("<DEVICE MAC ADDRESS>")
+
+        # Get all stored readings from a device (starting at a datetime):
+        await client.api.get_device_details(
+            "<DEVICE MAC ADDRESS>", end_date="2019-01-16"
+        )
 
 
 asyncio.get_event_loop().run_until_complete(main())
@@ -129,71 +133,76 @@ from aioambient import Client
 async def main() -> None:
     """Create the aiohttp session and run the example."""
     async with ClientSession() as websession:
-      client = Client(
-        '<YOUR API KEY>',
-        '<YOUR APPLICATION KEY>',
-        websession)
+        client = Client("<YOUR API KEY>", "<YOUR APPLICATION KEY>", websession)
 
-      # Define a method that should be fired when the websocket client 
-      # connects:
-      def connect_method():
-          """Print a simple "hello" message."""
-          print('Client has connected to the websocket')
-      client.websocket.on_connect(connect_method)
+        # Define a method that should be fired when the websocket client
+        # connects:
+        def connect_method():
+            """Print a simple "hello" message."""
+            print("Client has connected to the websocket")
 
-      # Alternatively, define a coroutine handler:
-      async def connect_coroutine():
-          """Waits for 3 seconds, then print a simple "hello" message."""
-          await asyncio.sleep(3)
-          print('Client has connected to the websocket')
-      client.websocket.async_on_connect(connect_coroutine)
+        client.websocket.on_connect(connect_method)
 
-      # Define a method that should be run upon subscribing to the Ambient 
-      # Weather cloud:
-      def subscribed_method(data):
-          """Print the data received upon subscribing."""
-          print('Subscription data received: {0}'.format(data))
-      client.websocket.on_subscribed(subscribed_method)
+        # Alternatively, define a coroutine handler:
+        async def connect_coroutine():
+            """Waits for 3 seconds, then print a simple "hello" message."""
+            await asyncio.sleep(3)
+            print("Client has connected to the websocket")
 
-      # Alternatively, define a coroutine handler:
-      async def subscribed_coroutine(data):
-          """Waits for 3 seconds, then print the incoming data."""
-          await asyncio.sleep(3)
-          print('Subscription data received: {0}'.format(data))
-      client.websocket.async_on_subscribed(subscribed_coroutine)
+        client.websocket.async_on_connect(connect_coroutine)
 
-      # Define a method that should be run upon receiving data:
-      def data_method(data):
-          """Print the data received."""
-          print('Data received: {0}'.format(data))
-      client.websocket.on_data(data_method)
+        # Define a method that should be run upon subscribing to the Ambient
+        # Weather cloud:
+        def subscribed_method(data):
+            """Print the data received upon subscribing."""
+            print(f"Subscription data received: {data}")
 
-      # Alternatively, define a coroutine handler:
-      async def data_coroutine(data):
-          """Wait for 3 seconds, then print the data received."""
-          await asyncio.sleep(3)
-          print('Data received: {0}'.format(data))
-      client.websocket.async_on_data(data_coroutine)
+        client.websocket.on_subscribed(subscribed_method)
 
-      # Define a method that should be run when the websocket client 
-      # disconnects:
-      def disconnect_method(data):
-          """Print a simple "goodbye" message."""
-          print('Client has disconnected from the websocket')
-      client.websocket.on_disconnect(disconnect_method)
+        # Alternatively, define a coroutine handler:
+        async def subscribed_coroutine(data):
+            """Waits for 3 seconds, then print the incoming data."""
+            await asyncio.sleep(3)
+            print(f"Subscription data received: {data}")
 
-      # Alternatively, define a coroutine handler:
-      async def disconnect_coroutine(data):
-          """Wait for 3 seconds, then print a simple "goodbye" message."""
-          await asyncio.sleep(3)
-          print('Client has disconnected from the websocket')
-      client.websocket.async_on_disconnect(disconnect_coroutine)
+        client.websocket.async_on_subscribed(subscribed_coroutine)
 
-      # Connect to the websocket:
-      await client.websocket.connect()
+        # Define a method that should be run upon receiving data:
+        def data_method(data):
+            """Print the data received."""
+            print(f"Data received: {data}")
 
-      # At any point, disconnect from the websocket:
-      await client.websocket.disconnect()
+        client.websocket.on_data(data_method)
+
+        # Alternatively, define a coroutine handler:
+        async def data_coroutine(data):
+            """Wait for 3 seconds, then print the data received."""
+            await asyncio.sleep(3)
+            print(f"Data received: {data}")
+
+        client.websocket.async_on_data(data_coroutine)
+
+        # Define a method that should be run when the websocket client
+        # disconnects:
+        def disconnect_method(data):
+            """Print a simple "goodbye" message."""
+            print("Client has disconnected from the websocket")
+
+        client.websocket.on_disconnect(disconnect_method)
+
+        # Alternatively, define a coroutine handler:
+        async def disconnect_coroutine(data):
+            """Wait for 3 seconds, then print a simple "goodbye" message."""
+            await asyncio.sleep(3)
+            print("Client has disconnected from the websocket")
+
+        client.websocket.async_on_disconnect(disconnect_coroutine)
+
+        # Connect to the websocket:
+        await client.websocket.connect()
+
+        # At any point, disconnect from the websocket:
+        await client.websocket.disconnect()
 
 
 loop = asyncio.get_event_loop()

--- a/aioambient/api.py
+++ b/aioambient/api.py
@@ -37,7 +37,7 @@ class API:
         # https://ambientweather.docs.apiary.io/#introduction/rate-limiting
         await asyncio.sleep(1)
 
-        url = "{0}/v{1}/{2}".format(REST_API_BASE, self._api_version, endpoint)
+        url = f"{REST_API_BASE}/v{self._api_version}/{endpoint}"
 
         if not params:
             params = {}
@@ -50,9 +50,7 @@ class API:
                 resp.raise_for_status()
                 return await resp.json(content_type=None)
             except ClientError as err:
-                raise RequestError(
-                    "Error requesting data from {0}: {1}".format(url, err)
-                )
+                raise RequestError(f"Error requesting data from {url}: {err}")
 
     async def get_devices(self) -> list:
         """Get all devices associated with an API key."""
@@ -66,6 +64,4 @@ class API:
         if end_date:
             params["endDate"] = end_date.isoformat()  # type: ignore
 
-        return await self._request(
-            "get", "devices/{0}".format(mac_address), params=params
-        )
+        return await self._request("get", f"devices/{mac_address}", params=params)

--- a/aioambient/websocket.py
+++ b/aioambient/websocket.py
@@ -17,7 +17,7 @@ class Websocket:
         """Initialize."""
         self._api_key = api_key
         self._api_version = api_version
-        self._application_key = application_key
+        self._app_key = application_key
         self._async_user_connect_handler = None
         self._sio = AsyncClient()
         self._user_connect_handler = None
@@ -70,9 +70,7 @@ class Websocket:
         try:
             self._sio.on("connect", self._init_connection)
             await self._sio.connect(
-                "{0}/?api={1}&applicationKey={2}".format(
-                    WEBSOCKET_API_BASE, self._api_version, self._application_key
-                ),
+                f"{WEBSOCKET_API_BASE}/?api={self._api_version}&applicationKey={self._app_key}",
                 transports=["websocket"],
             )
         except (ConnectionError, SocketIOError) as err:

--- a/setup.py
+++ b/setup.py
@@ -14,20 +14,20 @@ from shutil import rmtree
 from setuptools import find_packages, setup, Command
 
 # Package meta-data.
-NAME = 'aioambient'
-DESCRIPTION = 'A clean, async-friendly library for the Ambient Weather API'
-URL = 'https://github.com/bachya/aioambient'
-EMAIL = 'bachya1208@gmail.com'
-AUTHOR = 'Aaron Bach'
-REQUIRES_PYTHON = '>=3.5.3'
+NAME = "aioambient"
+DESCRIPTION = "A clean, async-friendly library for the Ambient Weather API"
+URL = "https://github.com/bachya/aioambient"
+EMAIL = "bachya1208@gmail.com"
+AUTHOR = "Aaron Bach"
+REQUIRES_PYTHON = ">=3.6.0"
 VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [  # type: ignore
-    'aiohttp',
-    'python-engineio>=3.9.3',
-    'python-socketio[asyncio_client]>=4.3.1',
-    'websockets'
+    "aiohttp",
+    "python-engineio>=3.9.3",
+    "python-socketio[asyncio_client]>=4.3.1",
+    "websockets",
 ]
 
 # The rest you shouldn't have to touch too much :)
@@ -40,29 +40,28 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!
-with io.open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
-    LONG_DESC = '\n' + f.read()
+with io.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
+    LONG_DESC = "\n" + f.read()
 
 # Load the package's __version__.py module as a dictionary.
 ABOUT = {}  # type: ignore
 if not VERSION:
-    with open(os.path.join(HERE, NAME, 'const.py')) as f:
+    with open(os.path.join(HERE, NAME, "const.py")) as f:
         exec(f.read(), ABOUT)  # pylint: disable=exec-used
 else:
-    ABOUT['__version__'] = VERSION
-
+    ABOUT["__version__"] = VERSION
 
 
 class UploadCommand(Command):
     """Support setup.py upload."""
 
-    description = 'Build and publish the package.'
+    description = "Build and publish the package."
     user_options = []  # type: ignore
 
     @staticmethod
     def status(string):
-        """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(string))
+        """Print things in bold."""
+        print(f"\033[1m{string}\033[0m")
 
     def initialize_options(self):
         """Add options for initialization."""
@@ -75,21 +74,20 @@ class UploadCommand(Command):
     def run(self):
         """Run."""
         try:
-            self.status('Removing previous builds…')
-            rmtree(os.path.join(HERE, 'dist'))
+            self.status("Removing previous builds…")
+            rmtree(os.path.join(HERE, "dist"))
         except OSError:
             pass
 
-        self.status('Building Source and Wheel (universal) distribution…')
-        os.system('{0} setup.py sdist bdist_wheel --universal'.format(
-            sys.executable))
+        self.status("Building Source and Wheel (universal) distribution…")
+        os.system(f"{sys.executable} setup.py sdist bdist_wheel --universal")
 
-        self.status('Uploading the package to PyPi via Twine…')
-        os.system('twine upload dist/*')
+        self.status("Uploading the package to PyPi via Twine…")
+        os.system("twine upload dist/*")
 
-        self.status('Pushing git tags…')
-        os.system('git tag v{0}'.format(ABOUT['__version__']))
-        os.system('git push --tags')
+        self.status("Pushing git tags…")
+        os.system(f"git tag v{ABOUT['__version__']}")
+        os.system("git push --tags")
 
         sys.exit()
 
@@ -97,38 +95,34 @@ class UploadCommand(Command):
 # Where the magic happens:
 setup(
     name=NAME,
-    version=ABOUT['__version__'],
+    version=ABOUT["__version__"],
     description=DESCRIPTION,
     long_description=LONG_DESC,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author=AUTHOR,
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    packages=find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=("tests",)),
     # If your package is a single module, use this instead of 'packages':
     # py_modules=['mypackage'],
-
     # entry_points={
     #     'console_scripts': ['mycli=mymodule:cli'],
     # },
     install_requires=REQUIRED,
     include_package_data=True,
-    license='MIT',
+    license="MIT",
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy'
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     # $ setup.py publish support.
-    cmdclass={
-        'upload': UploadCommand,
-    },
+    cmdclass={"upload": UploadCommand},
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,7 +32,7 @@ async def test_api_error(aresponses, event_loop, devices_json):
 async def test_get_device_details(aresponses, event_loop, device_details_json):
     aresponses.add(
         "api.ambientweather.net",
-        "/v1/devices/{0}".format(TEST_MAC),
+        f"/v1/devices/{TEST_MAC}",
         "get",
         aresponses.Response(text=json.dumps(device_details_json), status=200),
     )

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -34,9 +34,7 @@ async def test_connect_async_success(event_loop):
 
         await client.websocket.connect()
         client.websocket._sio.eio.connect.mock.assert_called_once_with(
-            "https://dash2.ambientweather.net/?api=1&applicationKey={0}".format(
-                TEST_APP_KEY
-            ),
+            f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
             engineio_path="socket.io",
             headers={},
             transports=["websocket"],
@@ -58,9 +56,7 @@ async def test_connect_sync_success(event_loop):
 
         await client.websocket.connect()
         client.websocket._sio.eio.connect.mock.assert_called_once_with(
-            "https://dash2.ambientweather.net/?api=1&applicationKey={0}".format(
-                TEST_APP_KEY
-            ),
+            f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
             engineio_path="socket.io",
             headers={},
             transports=["websocket"],
@@ -99,9 +95,7 @@ async def async_test_events(event_loop):
 
         await client.websocket.connect()
         client.websocket._sio.eio.connect.mock.assert_called_once_with(
-            "https://dash2.ambientweather.net/?api=1&applicationKey={0}".format(
-                TEST_APP_KEY
-            ),
+            f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
             engineio_path="socket.io",
             headers={},
             transports=["websocket"],
@@ -141,9 +135,7 @@ async def test_events(event_loop):
 
         await client.websocket.connect()
         client.websocket._sio.eio.connect.mock.assert_called_once_with(
-            "https://dash2.ambientweather.net/?api=1&applicationKey={0}".format(
-                TEST_APP_KEY
-            ),
+            f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
             engineio_path="socket.io",
             headers={},
             transports=["websocket"],


### PR DESCRIPTION
**Describe what the PR does:**

This PR drops runtime support for Python 3.5.3 and makes the minimum runtime version 3.6. One of a few benefits to follow: we now get to use f-strings.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
