### PR TITLE
Add Python 3.6-style variable type annotations

### DIFF
--- a/aioambient/api.py
+++ b/aioambient/api.py
@@ -1,14 +1,15 @@
 """Define an object to interact with the REST API."""
 import asyncio
 from datetime import datetime
+from typing import Any, Dict
 
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError
 
 from .errors import RequestError
 
-REST_API_BASE = "https://api.ambientweather.net"
-DEFAULT_LIMIT = 288
+REST_API_BASE: str = "https://api.ambientweather.net"
+DEFAULT_LIMIT: int = 288
 
 
 class API:
@@ -22,10 +23,10 @@ class API:
         session: ClientSession,
     ) -> None:
         """Initialize."""
-        self._api_key = api_key
-        self._api_version = api_version
-        self._application_key = application_key
-        self._session = session
+        self._api_key: str = api_key
+        self._api_version: int = api_version
+        self._application_key: str = application_key
+        self._session: ClientSession = session
 
     async def _request(
         self, method: str, endpoint: str, *, params: dict = None
@@ -37,7 +38,7 @@ class API:
         # https://ambientweather.docs.apiary.io/#introduction/rate-limiting
         await asyncio.sleep(1)
 
-        url = f"{REST_API_BASE}/v{self._api_version}/{endpoint}"
+        url: str = f"{REST_API_BASE}/v{self._api_version}/{endpoint}"
 
         if not params:
             params = {}
@@ -60,8 +61,8 @@ class API:
         self, mac_address: str, *, end_date: datetime = None, limit: int = DEFAULT_LIMIT
     ) -> list:
         """Get details of a device by MAC address."""
-        params = {"limit": limit}
+        params: Dict[str, Any] = {"limit": limit}
         if end_date:
-            params["endDate"] = end_date.isoformat()  # type: ignore
+            params["endDate"] = end_date.isoformat()
 
         return await self._request("get", f"devices/{mac_address}", params=params)

--- a/aioambient/client.py
+++ b/aioambient/client.py
@@ -1,7 +1,5 @@
 """Define a client to interact with the Ambient Weather APIs."""
-# pylint: disable=unused-import
 import logging
-from typing import Dict, List, Union  # noqa
 
 from aiohttp import ClientSession
 
@@ -25,5 +23,5 @@ class Client:  # pylint: disable=too-few-public-methods
         api_version: int = DEFAULT_API_VERSION
     ) -> None:
         """Initialize."""
-        self.api = API(application_key, api_key, api_version, session)
-        self.websocket = Websocket(application_key, api_key, api_version)
+        self.api: API = API(application_key, api_key, api_version, session)
+        self.websocket: Websocket = Websocket(application_key, api_key, api_version)

--- a/aioambient/const.py
+++ b/aioambient/const.py
@@ -1,2 +1,2 @@
 """Define package constants."""
-__version__ = "0.3.2"
+__version__: str = "0.3.2"

--- a/aioambient/websocket.py
+++ b/aioambient/websocket.py
@@ -1,13 +1,15 @@
 """Define an object to interact with the Websocket API."""
-# pylint: disable=redefined-builtin,unused-argument
-from typing import Awaitable, Callable, Union
+from typing import Awaitable, Callable, Optional, Union
 
 from socketio import AsyncClient
-from socketio.exceptions import ConnectionError, SocketIOError
+from socketio.exceptions import (  # pylint: disable=redefined-builtin
+    ConnectionError,
+    SocketIOError,
+)
 
 from .errors import WebsocketError
 
-WEBSOCKET_API_BASE = "https://dash2.ambientweather.net"
+WEBSOCKET_API_BASE: str = "https://dash2.ambientweather.net"
 
 
 class Websocket:
@@ -15,31 +17,31 @@ class Websocket:
 
     def __init__(self, application_key: str, api_key: str, api_version: int) -> None:
         """Initialize."""
-        self._api_key = api_key
-        self._api_version = api_version
-        self._app_key = application_key
-        self._async_user_connect_handler = None
-        self._sio = AsyncClient()
-        self._user_connect_handler = None
+        self._api_key: str = api_key
+        self._api_version: int = api_version
+        self._app_key: str = application_key
+        self._async_user_connect_handler: Optional[Awaitable] = None
+        self._sio: AsyncClient = AsyncClient()
+        self._user_connect_handler: Optional[Callable] = None
 
     async def _init_connection(self) -> None:
         """Perform automatic initialization upon connecting."""
         await self._sio.emit("subscribe", {"apiKeys": [self._api_key]})
 
         if self._async_user_connect_handler:
-            await self._async_user_connect_handler()
+            await self._async_user_connect_handler()  # type: ignore
         elif self._user_connect_handler:
             self._user_connect_handler()
 
     def async_on_connect(self, target: Awaitable) -> None:
         """Define a coroutine to be called when connecting."""
-        self._async_user_connect_handler = target  # type: ignore
+        self._async_user_connect_handler = target
         self._user_connect_handler = None
 
-    def on_connect(self, target: Union[Awaitable, Callable]) -> None:
+    def on_connect(self, target: Callable) -> None:
         """Define a method to be called when connecting."""
         self._async_user_connect_handler = None
-        self._user_connect_handler = target  # type: ignore
+        self._user_connect_handler = target
 
     def async_on_data(self, target: Awaitable) -> None:
         """Define a coroutine to be called when data is received."""


### PR DESCRIPTION
**Describe what the PR does:**

Now that we can ensure a minimum of Python 3.6, we can use Python 3.6-style type annotations for variables.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
