### PR TITLE
Pin python-engineio and python-socketio to stable versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = "^3.6.2"
 python = "^3.6.1"
-python-engineio = ">= 3.9.3"
-python-socketio = ">=4.3.1"
+python-engineio = "=3.10.0"
+python-socketio = "=4.4.0"
 websockets = "^8.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
**Describe what the PR does:**

[A recent change in `python-engineio` broke the websocket API that we implement.](https://github.com/miguelgrinberg/python-engineio/issues/152) This PR pins specific versions of it (and `python-socketio`) in place to prevent future issues like this.

**Does this fix a specific issue?**

https://github.com/bachya/aioambient/issues/21
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
