### PR TITLE
Specify which pre-commit repos to run in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,5 +79,12 @@ jobs:
           python -m venv venv
           venv/bin/pip install pre-commit
           venv/bin/pre-commit install-hooks --config .pre-commit-config.yaml
-          venv/bin/pre-commit run --all-files
+          venv/bin/pre-commit run bandit --all-files
+          venv/bin/pre-commit run black --all-files
+          venv/bin/pre-commit run check-json --all-files
+          venv/bin/pre-commit run codespell --all-files
+          venv/bin/pre-commit run flake8 --all-files
+          venv/bin/pre-commit run isort --all-files
+          venv/bin/pre-commit run mypy --all-files
+          venv/bin/pre-commit run pydocstyle --all-files
           shellcheck script/*


### PR DESCRIPTION
**Describe what the PR does:**

#41 accidentally ensured that the `no-commit-to-branch` repo would be run in CI; since those runs include the `dev` and `master` branches, it would always fail. This PR updates CI to run specific `pre-commit` repos, rather than any repo defined.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
