### PR TITLE
Bump python-socketio and python-engineio to latest stable versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = "^3.6.2"
 python = "^3.6.1"
-python-engineio = "=3.11.2"
+python-engineio = "=3.12.1"
 python-socketio = "=4.5.0"
 websockets = "^8.1"
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,5 +3,5 @@ aresponses==1.1.2
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
 pytest==5.3.5
-python-engineio==3.10.0
-python-socketio==4.4.0
+python-engineio==3.12.1
+python-socketio==4.5.0


### PR DESCRIPTION
**Describe what the PR does:**

This PR bumps `python-socketio` and `python-engineio` to their latest stable versions (4.5.0 and 3.12.1, respectively).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
