### PR TITLE
Add a websocket watchdog

### DIFF
--- a/aioambient/websocket.py
+++ b/aioambient/websocket.py
@@ -1,6 +1,9 @@
 """Define an object to interact with the Websocket API."""
-from typing import Awaitable, Callable, Optional, Union
+import asyncio
+import logging
+from typing import Awaitable, Callable, Optional
 
+from aiohttp.client_exceptions import ClientConnectionError, ClientOSError
 from socketio import AsyncClient
 from socketio.exceptions import (  # pylint: disable=redefined-builtin
     ConnectionError,
@@ -9,7 +12,49 @@ from socketio.exceptions import (  # pylint: disable=redefined-builtin
 
 from .errors import WebsocketError
 
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_WATCHDOG_TIMEOUT = 900
+
 WEBSOCKET_API_BASE: str = "https://dash2.ambientweather.net"
+
+
+class WebsocketWatchdog:
+    """Define a watchdog to kick the websocket connection at intervals."""
+
+    def __init__(
+        self,
+        action: Callable[..., Awaitable],
+        *,
+        timeout_seconds: int = DEFAULT_WATCHDOG_TIMEOUT,
+    ):
+        """Initialize."""
+        self._action: Callable[..., Awaitable] = action
+        self._loop = asyncio.get_event_loop()
+        self._timer_task: Optional[asyncio.TimerHandle] = None
+        self._timeout: int = timeout_seconds
+
+    def cancel(self):
+        """Cancel the watchdog."""
+        if self._timer_task:
+            self._timer_task.cancel()
+            self._timer_task = None
+
+    async def on_expire(self):
+        """Log and act when the watchdog expires."""
+        _LOGGER.info("Watchdog expired – calling %s", self._action.__name__)
+        await self._action()
+
+    async def trigger(self):
+        """Trigger the watchdog."""
+        _LOGGER.info("Watchdog triggered – sleeping for %s seconds", self._timeout)
+
+        if self._timer_task:
+            self._timer_task.cancel()
+
+        self._timer_task = self._loop.call_later(
+            self._timeout, lambda: asyncio.create_task(self.on_expire())
+        )
 
 
 class Websocket:
@@ -20,9 +65,10 @@ class Websocket:
         self._api_key: str = api_key
         self._api_version: int = api_version
         self._app_key: str = application_key
-        self._async_user_connect_handler: Optional[Awaitable] = None
+        self._async_user_connect_handler: Optional[Callable[..., Awaitable]] = None
         self._sio: AsyncClient = AsyncClient()
         self._user_connect_handler: Optional[Callable] = None
+        self._watchdog: WebsocketWatchdog = WebsocketWatchdog(self.reconnect)
 
     async def _init_connection(self) -> None:
         """Perform automatic initialization upon connecting."""
@@ -33,7 +79,7 @@ class Websocket:
         elif self._user_connect_handler:
             self._user_connect_handler()
 
-    def async_on_connect(self, target: Awaitable) -> None:
+    def async_on_connect(self, target: Callable[..., Awaitable]) -> None:
         """Define a coroutine to be called when connecting."""
         self._async_user_connect_handler = target
         self._user_connect_handler = None
@@ -43,29 +89,69 @@ class Websocket:
         self._async_user_connect_handler = None
         self._user_connect_handler = target
 
-    def async_on_data(self, target: Awaitable) -> None:
+    def async_on_data(self, target: Callable[..., Awaitable]) -> None:  # noqa: D202
         """Define a coroutine to be called when data is received."""
-        self.on_data(target)
 
-    def on_data(self, target: Union[Awaitable, Callable]) -> None:
+        async def _async_on_data(data: dict):
+            """Act on the data."""
+            await self._watchdog.trigger()
+            await target(data)
+
+        self._sio.on("data", _async_on_data)
+
+    def on_data(self, target: Callable) -> None:  # noqa: D202
         """Define a method to be called when data is received."""
-        self._sio.on("data", target)
 
-    def async_on_disconnect(self, target: Awaitable) -> None:
+        async def _async_on_data(data: dict):
+            """Act on the data."""
+            await self._watchdog.trigger()
+            target(data)
+
+        self._sio.on("data", _async_on_data)
+
+    def async_on_disconnect(
+        self, target: Callable[..., Awaitable]
+    ) -> None:  # noqa: D202
         """Define a coroutine to be called when disconnecting."""
-        self.on_disconnect(target)
 
-    def on_disconnect(self, target: Union[Awaitable, Callable]) -> None:
+        async def _async_on_disconnect():
+            """Act on disconnect."""
+            self._watchdog.cancel()
+            await target()
+
+        self._sio.on("disconnect", _async_on_disconnect)
+
+    def on_disconnect(self, target: Callable) -> None:  # noqa: D202
         """Define a method to be called when disconnecting."""
-        self._sio.on("disconnect", target)
 
-    def async_on_subscribed(self, target: Awaitable) -> None:
+        def _async_on_disconnect():
+            """Act on disconnect."""
+            self._watchdog.cancel()
+            target()
+
+        self._sio.on("disconnect", _async_on_disconnect)
+
+    def async_on_subscribed(
+        self, target: Callable[..., Awaitable]
+    ) -> None:  # noqa: D202
         """Define a coroutine to be called when subscribed."""
-        self.on_subscribed(target)
 
-    def on_subscribed(self, target: Union[Awaitable, Callable]) -> None:
+        async def _async_on_subscribed(data):
+            """Act on subscribe."""
+            await self._watchdog.trigger()
+            await target(data)
+
+        self._sio.on("subscribed", _async_on_subscribed)
+
+    def on_subscribed(self, target: Callable) -> None:  # noqa: D202
         """Define a method to be called when subscribed."""
-        self._sio.on("subscribed", target)
+
+        async def _async_on_subscribed(data):
+            """Act on subscribe."""
+            await self._watchdog.trigger()
+            target(data)
+
+        self._sio.on("subscribed", _async_on_subscribed)
 
     async def connect(self) -> None:
         """Connect to the socket."""
@@ -75,9 +161,20 @@ class Websocket:
                 f"{WEBSOCKET_API_BASE}/?api={self._api_version}&applicationKey={self._app_key}",
                 transports=["websocket"],
             )
-        except (ConnectionError, SocketIOError) as err:
+        except (
+            ClientConnectionError,
+            ClientOSError,
+            ConnectionError,
+            SocketIOError,
+        ) as err:
             raise WebsocketError(err) from None
 
     async def disconnect(self) -> None:
         """Disconnect from the socket."""
         await self._sio.disconnect()
+
+    async def reconnect(self) -> None:
+        """Reconnect the websocket connection."""
+        await self._sio.disconnect()
+        await asyncio.sleep(1)
+        await self.connect()

--- a/examples/test_websocket.py
+++ b/examples/test_websocket.py
@@ -28,6 +28,11 @@ def print_hello():
     _LOGGER.info("Client has connected to the websocket")
 
 
+def print_subscribed(data):
+    """Print subscription data as it is received."""
+    _LOGGER.info("Client has subscribed: %s", data)
+
+
 async def main() -> None:
     """Run the websocket example."""
     logging.basicConfig(level=logging.INFO)
@@ -38,7 +43,7 @@ async def main() -> None:
         client.websocket.on_connect(print_hello)
         client.websocket.on_data(print_data)
         client.websocket.on_disconnect(print_goodbye)
-        client.websocket.on_subscribed(print_data)
+        client.websocket.on_subscribed(print_subscribed)
 
         try:
             await client.websocket.connect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ websockets = "^8.1"
 
 [tool.poetry.dev-dependencies]
 aresponses = "^2.0.0"
+asynctest = "^0.13.0"
 pre-commit = "^2.0.1"
 pytest = "^5.3.5"
 pytest-aiohttp = "^0.3.0"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,6 @@
 aiohttp==3.6.2
 aresponses==1.1.2
+asynctest==0.13.0
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
 pytest==5.3.5

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,157 +1,180 @@
 """Define tests for the Websocket API."""
 # pylint: disable=protected-access
-from unittest.mock import MagicMock
-
 import aiohttp
+from asynctest import CoroutineMock, MagicMock
 import pytest
 from socketio.exceptions import SocketIOError
 
 from aioambient import Client
 from aioambient.errors import WebsocketError
+from aioambient.websocket import WebsocketWatchdog
 
 from .common import TEST_API_KEY, TEST_APP_KEY
-
-
-def async_mock(*args, **kwargs):
-    """Return a mock asynchronous function."""
-    mock = MagicMock(*args, **kwargs)
-
-    async def mock_coro(*args, **kwargs):
-        return mock(*args, **kwargs)
-
-    mock_coro.mock = mock
-    return mock_coro
 
 
 async def test_connect_async_success(event_loop):
     """Test connecting to the socket with an async handler."""
     async with aiohttp.ClientSession(loop=event_loop) as session:
         client = Client(TEST_API_KEY, TEST_APP_KEY, session)
-        client.websocket._sio.eio._trigger_event = async_mock()
-        client.websocket._sio.eio.connect = async_mock()
+        client.websocket._sio.eio._trigger_event = CoroutineMock()
+        client.websocket._sio.eio.connect = CoroutineMock()
 
-        on_connect = async_mock()
-        client.websocket.async_on_connect(on_connect)
+        async_on_connect = CoroutineMock()
+        client.websocket.async_on_connect(async_on_connect)
 
         await client.websocket.connect()
-        client.websocket._sio.eio.connect.mock.assert_called_once_with(
+        client.websocket._sio.eio.connect.assert_called_once_with(
             f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
             engineio_path="socket.io",
             headers={},
             transports=["websocket"],
         )
 
-        await client.websocket._sio._trigger_event("connect", namespace="/")
-        on_connect.mock.assert_called_once()
+        await client.websocket._sio._trigger_event("connect", "/")
+        async_on_connect.assert_called_once()
 
 
 async def test_connect_sync_success(event_loop):
     """Test connecting to the socket with a sync handler."""
     async with aiohttp.ClientSession(loop=event_loop) as session:
         client = Client(TEST_API_KEY, TEST_APP_KEY, session)
-        client.websocket._sio.eio._trigger_event = async_mock()
-        client.websocket._sio.eio.connect = async_mock()
+        client.websocket._sio.eio._trigger_event = CoroutineMock()
+        client.websocket._sio.eio.connect = CoroutineMock()
 
-        on_connect = MagicMock()
-        client.websocket.on_connect(on_connect)
+        async_on_connect = CoroutineMock()
+        client.websocket.async_on_connect(async_on_connect)
 
         await client.websocket.connect()
-        client.websocket._sio.eio.connect.mock.assert_called_once_with(
+        client.websocket._sio.eio.connect.assert_called_once_with(
             f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
             engineio_path="socket.io",
             headers={},
             transports=["websocket"],
         )
 
-        await client.websocket._sio._trigger_event("connect", namespace="/")
-        on_connect.assert_called_once()
+        await client.websocket._sio._trigger_event("connect", "/")
+        async_on_connect.assert_called_once()
 
 
 async def test_connect_failure(event_loop):
     """Test connecting to the socket and an exception occurring."""
     async with aiohttp.ClientSession(loop=event_loop) as session:
         client = Client(TEST_API_KEY, TEST_APP_KEY, session)
-        client.websocket._sio.eio.connect = async_mock(side_effect=SocketIOError())
+        client.websocket._sio.eio.connect = CoroutineMock(side_effect=SocketIOError())
 
         with pytest.raises(WebsocketError):
             await client.websocket.connect()
 
 
-async def async_test_events(event_loop):
-    """Test all events and async_handlers."""
+async def test_data_async(event_loop):
+    """Test data and subscription with async handlers."""
     async with aiohttp.ClientSession(loop=event_loop) as session:
         client = Client(TEST_API_KEY, TEST_APP_KEY, session)
-        client.websocket._sio.eio._trigger_event = async_mock()
-        client.websocket._sio.eio.connect = async_mock()
-        client.websocket._sio.eio.disconnect = async_mock()
+        client.websocket._sio.eio._trigger_event = CoroutineMock()
+        client.websocket._sio.eio.connect = CoroutineMock()
+        client.websocket._sio.eio.disconnect = CoroutineMock()
+
+        async_on_connect = CoroutineMock()
+        async_on_data = CoroutineMock()
+        async_on_disconnect = CoroutineMock()
+        async_on_subscribed = CoroutineMock()
+
+        client.websocket.async_on_connect(async_on_connect)
+        client.websocket.async_on_data(async_on_data)
+        client.websocket.async_on_disconnect(async_on_disconnect)
+        client.websocket.async_on_subscribed(async_on_subscribed)
+
+        await client.websocket.connect()
+        client.websocket._sio.eio.connect.assert_called_once_with(
+            f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
+            engineio_path="socket.io",
+            headers={},
+            transports=["websocket"],
+        )
+
+        await client.websocket._sio._trigger_event("connect", "/")
+        async_on_connect.assert_called_once()
+
+        await client.websocket._sio._trigger_event("data", "/", {"foo": "bar"})
+        async_on_data.assert_called_once()
+
+        await client.websocket._sio._trigger_event("subscribed", "/", {"foo": "bar"})
+        async_on_subscribed.assert_called()
+
+        await client.websocket.disconnect()
+        await client.websocket._sio._trigger_event("disconnect", "/")
+        async_on_disconnect.assert_called_once()
+        client.websocket._sio.eio.disconnect.assert_called_once_with(abort=True)
+
+
+async def test_data_sync(event_loop):
+    """Test data and subscription with sync handlers."""
+    async with aiohttp.ClientSession(loop=event_loop) as session:
+        client = Client(TEST_API_KEY, TEST_APP_KEY, session)
+        client.websocket._sio.eio._trigger_event = CoroutineMock()
+        client.websocket._sio.eio.connect = CoroutineMock()
+        client.websocket._sio.eio.disconnect = CoroutineMock()
 
         on_connect = MagicMock()
         on_data = MagicMock()
+        on_disconnect = MagicMock()
         on_subscribed = MagicMock()
 
         client.websocket.on_connect(on_connect)
         client.websocket.on_data(on_data)
-        client.websocket.on_disconnect(on_data)
+        client.websocket.on_disconnect(on_disconnect)
         client.websocket.on_subscribed(on_subscribed)
 
         await client.websocket.connect()
-        client.websocket._sio.eio.connect.mock.assert_called_once_with(
+        client.websocket._sio.eio.connect.assert_called_once_with(
             f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
             engineio_path="socket.io",
             headers={},
             transports=["websocket"],
         )
 
-        await client.websocket._sio._trigger_event("connect", namespace="/")
+        await client.websocket._sio._trigger_event("connect", "/")
         on_connect.assert_called_once()
 
-        await client.websocket._sio._trigger_event("data", namespace="/")
+        await client.websocket._sio._trigger_event("data", "/", {"foo": "bar"})
         on_data.assert_called_once()
 
-        await client.websocket._sio._trigger_event("subscribed", namespace="/")
+        await client.websocket._sio._trigger_event("subscribed", "/", {"foo": "bar"})
         on_subscribed.assert_called()
 
         await client.websocket.disconnect()
-        await client.websocket._sio._trigger_event("disconnect", namespace="/")
-        on_subscribed.assert_called_once()
-        client.websocket._sio.eio.disconnect.mock.assert_called_once_with(abort=True)
+        await client.websocket._sio._trigger_event("disconnect", "/")
+        on_disconnect.assert_called_once()
+        client.websocket._sio.eio.disconnect.assert_called_once_with(abort=True)
 
 
-async def test_events(event_loop):
-    """Test all events and handlers."""
+async def test_reconnect(event_loop):
+    """Test that reconnecting to the websocket does the right thing."""
     async with aiohttp.ClientSession(loop=event_loop) as session:
         client = Client(TEST_API_KEY, TEST_APP_KEY, session)
-        client.websocket._sio.eio._trigger_event = async_mock()
-        client.websocket._sio.eio.connect = async_mock()
-        client.websocket._sio.eio.disconnect = async_mock()
+        client.websocket._sio.eio._trigger_event = CoroutineMock()
+        client.websocket._sio.eio.connect = CoroutineMock()
 
-        on_connect = async_mock()
-        on_data = async_mock()
-        on_subscribed = async_mock()
+        async_on_connect = CoroutineMock()
+        async_on_disconnect = CoroutineMock()
 
-        client.websocket.async_on_connect(on_connect)
-        client.websocket.async_on_data(on_data)
-        client.websocket.async_on_disconnect(on_data)
-        client.websocket.async_on_subscribed(on_subscribed)
+        client.websocket.async_on_connect(async_on_connect)
+        client.websocket.async_on_disconnect(async_on_disconnect)
 
-        await client.websocket.connect()
-        client.websocket._sio.eio.connect.mock.assert_called_once_with(
-            f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
-            engineio_path="socket.io",
-            headers={},
-            transports=["websocket"],
-        )
+        await client.websocket.reconnect()
+        await client.websocket._sio._trigger_event("disconnect", "/")
+        async_on_disconnect.assert_called_once()
+        await client.websocket._sio._trigger_event("connect", "/")
+        async_on_connect.assert_called_once()
 
-        await client.websocket._sio._trigger_event("connect", namespace="/")
-        on_connect.mock.assert_called_once()
 
-        await client.websocket._sio._trigger_event("data", namespace="/")
-        on_data.mock.assert_called_once()
+@pytest.mark.asyncio
+async def test_watchdog_firing():
+    """Test that the watchdog expiring fires the provided coroutine."""
+    mock_coro = CoroutineMock()
+    mock_coro.__name__ = "mock_coro"
 
-        await client.websocket._sio._trigger_event("subscribed", namespace="/")
-        on_subscribed.mock.assert_called()
+    watchdog = WebsocketWatchdog(mock_coro)
 
-        await client.websocket.disconnect()
-        await client.websocket._sio._trigger_event("disconnect", namespace="/")
-        on_subscribed.mock.assert_called_once()
-        client.websocket._sio.eio.disconnect.mock.assert_called_once_with(abort=True)
+    await watchdog.on_expire()
+    mock_coro.assert_called_once()


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a watchdog to the websocket portion of the library – if data doesn't come down every 5 minutes, the connection is closed and re-established. This (combined with some broader exception handling) should help the library reconnect if the Ambient Weather websocket becomes flaky.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
