### PR TITLE
Re-introduce manual pre-commit in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,4 +90,16 @@ jobs:
           key: >
             pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
-      - uses: pre-commit/action@v1.0.1
+      - run: |
+          python -m venv venv
+          venv/bin/pip install pre-commit
+          venv/bin/pre-commit install-hooks --config .pre-commit-config.yaml
+          venv/bin/pre-commit run bandit --all-files
+          venv/bin/pre-commit run black --all-files
+          venv/bin/pre-commit run check-json --all-files
+          venv/bin/pre-commit run codespell --all-files
+          venv/bin/pre-commit run flake8 --all-files
+          venv/bin/pre-commit run isort --all-files
+          venv/bin/pre-commit run mypy --all-files
+          venv/bin/pre-commit run pydocstyle --all-files
+          venv/bin/pre-commit run shellcheck --all-files


### PR DESCRIPTION
**Describe what the PR does:**

#54's use of the `pre-commit` GitHub action unfortunately enforces _all_ hooks, which prevents us from merging PRs to `dev`. This PR keeps the caching from #54, but returns to manually specifying which hooks to run.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
