### PR TITLE
Unpin specific versions of python-socketio and python-engineio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = "^3.6.2"
 python = "^3.6.1"
-python-engineio = "=3.13.1"
-python-socketio = "=4.6.0"
+python-engineio = "^3.13.1"
+python-socketio = "^4.6.0"
 websockets = "^8.1"
 
 [tool.poetry.dev-dependencies]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,5 +4,5 @@ asynctest==0.13.0
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
 pytest==5.4.1
-python-engineio==3.13.0
+python-engineio==3.13.1
 python-socketio==4.6.0


### PR DESCRIPTION
**Describe what the PR does:**

This PR unpins specific versions of `python-socketio` and `python-engineio` (and instead merely sets minimum required versions of those libraries).

**Does this fix a specific issue?**

Fixes https://github.com/bachya/aioambient/issues/64
Fixes https://github.com/bachya/aioambient/issues/65
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
