### PR TITLE
Remove decommissioned API URL

### DIFF
--- a/aioambient/api.py
+++ b/aioambient/api.py
@@ -8,7 +8,7 @@ from aiohttp.client_exceptions import ClientError
 
 from .errors import RequestError
 
-REST_API_BASE: str = "https://dash2.ambientweather.net"
+REST_API_BASE: str = "https://api.ambientweather.net"
 
 DEFAULT_LIMIT: int = 288
 DEFAULT_TIMEOUT: int = 10

--- a/aioambient/websocket.py
+++ b/aioambient/websocket.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_WATCHDOG_TIMEOUT = 900
 
-WEBSOCKET_API_BASE: str = "https://dash2.ambientweather.net"
+WEBSOCKET_API_BASE: str = "https://api.ambientweather.net"
 
 
 class WebsocketWatchdog:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ from .common import TEST_API_KEY, TEST_APP_KEY, TEST_MAC, load_fixture
 async def test_api_error(aresponses):
     """Test the REST API raising an exception upon HTTP error."""
     aresponses.add(
-        "dash2.ambientweather.net",
+        "api.ambientweather.net",
         "/v1/devices",
         "get",
         aresponses.Response(text="", status=500),
@@ -31,7 +31,7 @@ async def test_api_error(aresponses):
 async def test_get_device_details(aresponses):
     """Test retrieving device details from the REST API."""
     aresponses.add(
-        "dash2.ambientweather.net",
+        "api.ambientweather.net",
         f"/v1/devices/{TEST_MAC}",
         "get",
         aresponses.Response(
@@ -52,7 +52,7 @@ async def test_get_device_details(aresponses):
 async def test_get_devices(aresponses):
     """Test retrieving devices from the REST API."""
     aresponses.add(
-        "dash2.ambientweather.net",
+        "api.ambientweather.net",
         "/v1/devices",
         "get",
         aresponses.Response(text=load_fixture("devices_response.json"), status=200),
@@ -69,7 +69,7 @@ async def test_get_devices(aresponses):
 async def test_session_from_scratch(aresponses):
     """Test that an aiohttp ClientSession is created on the fly if needed."""
     aresponses.add(
-        "dash2.ambientweather.net",
+        "api.ambientweather.net",
         "/v1/devices",
         "get",
         aresponses.Response(text=load_fixture("devices_response.json"), status=200),

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -24,7 +24,7 @@ async def test_connect_async_success(event_loop):
 
         await client.websocket.connect()
         client.websocket._sio.eio.connect.assert_called_once_with(
-            f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
+            f"https://api.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
             engineio_path="socket.io",
             headers={},
             transports=["websocket"],
@@ -46,7 +46,7 @@ async def test_connect_sync_success(event_loop):
 
         await client.websocket.connect()
         client.websocket._sio.eio.connect.assert_called_once_with(
-            f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
+            f"https://api.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
             engineio_path="socket.io",
             headers={},
             transports=["websocket"],
@@ -86,7 +86,7 @@ async def test_data_async(event_loop):
 
         await client.websocket.connect()
         client.websocket._sio.eio.connect.assert_called_once_with(
-            f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
+            f"https://api.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
             engineio_path="socket.io",
             headers={},
             transports=["websocket"],
@@ -127,7 +127,7 @@ async def test_data_sync(event_loop):
 
         await client.websocket.connect()
         client.websocket._sio.eio.connect.assert_called_once_with(
-            f"https://dash2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
+            f"https://api.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
             engineio_path="socket.io",
             headers={},
             transports=["websocket"],


### PR DESCRIPTION
**Describe what the PR does:**

A long time ago, the Ambient devs told me that I should use https://dash2.ambientweather.net instead of https://api.ambientweather.net (as it was deemed more stable). It now looks like https://dash2.ambientweather.net is no longer in service; using https://api.ambientweather.net seems to work fine. So, this PR makes that change.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/aioambient/issues/68
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
