### PR TITLE
Fix incorrect docs/usage of "end_date" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Create a client, initialize it, then get to it:
 
 ```python
 import asyncio
+from datetime import date
 
 from aiohttp import ClientSession
 
@@ -77,9 +78,9 @@ async def main() -> None:
         # Get all stored readings from a device:
         await client.api.get_device_details("<DEVICE MAC ADDRESS>")
 
-        # Get all stored readings from a device (starting at a datetime):
+        # Get all stored readings from a device (starting at a date):
         await client.api.get_device_details(
-            "<DEVICE MAC ADDRESS>", end_date="2019-01-16"
+            "<DEVICE MAC ADDRESS>", end_date=date(2019, 1, 16)
         )
 
 
@@ -90,6 +91,7 @@ asyncio.get_event_loop().run_until_complete(main())
 
 ```python
 import asyncio
+from datetime import date
 
 from aiohttp import ClientSession
 
@@ -108,7 +110,7 @@ async def main() -> None:
 
     # Get all stored readings from a device (starting at a datetime):
     await client.api.get_device_details(
-        "<DEVICE MAC ADDRESS>", end_date="2019-01-16"
+        "<DEVICE MAC ADDRESS>", end_date=date(2019, 1, 16)
     )
 
 
@@ -123,6 +125,7 @@ pooling:
 
 ```python
 import asyncio
+from datetime import date
 
 from aiohttp import ClientSession
 
@@ -142,7 +145,7 @@ async def main() -> None:
 
         # Get all stored readings from a device (starting at a datetime):
         await client.api.get_device_details(
-            "<DEVICE MAC ADDRESS>", end_date="2019-01-16"
+            "<DEVICE MAC ADDRESS>", end_date=date(2019, 1, 16)
         )
 
 

--- a/aioambient/api.py
+++ b/aioambient/api.py
@@ -1,6 +1,6 @@
 """Define an object to interact with the REST API."""
 import asyncio
-from datetime import datetime
+from datetime import date
 from typing import Any, Dict, Optional
 
 from aiohttp import ClientSession, ClientTimeout
@@ -66,7 +66,11 @@ class API:
         return await self._request("get", "devices")
 
     async def get_device_details(
-        self, mac_address: str, *, end_date: datetime = None, limit: int = DEFAULT_LIMIT
+        self,
+        mac_address: str,
+        *,
+        end_date: Optional[date] = None,
+        limit: int = DEFAULT_LIMIT,
     ) -> list:
         """Get details of a device by MAC address."""
         params: Dict[str, Any] = {"limit": limit}


### PR DESCRIPTION
**Describe what the PR does:**

The docs previously described using a string for the `end_date` parameter (`API.get_device_details`), which isn't correct. This PR fixes the docs (and suggested usage) to properly reflect using a `datetime.date` object.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/aioambient/issues/78
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
