### PR TITLE
Force underlying libraries to use this package's logger

### DIFF
--- a/aioambient/client.py
+++ b/aioambient/client.py
@@ -1,13 +1,10 @@
 """Define a client to interact with the Ambient Weather APIs."""
-import logging
 from typing import Optional
 
 from aiohttp import ClientSession
 
 from .api import API
 from .websocket import Websocket
-
-_LOGGER = logging.getLogger(__name__)
 
 DEFAULT_API_VERSION = 1
 

--- a/aioambient/const.py
+++ b/aioambient/const.py
@@ -1,0 +1,4 @@
+"""Define package constants."""
+import logging
+
+LOGGER = logging.getLogger(__package__)


### PR DESCRIPTION
**Describe what the PR does:**

This PR ensures that the underlying `python-socketio` and `python-engineio` packages use this package's logger, rather than their own.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
