### PR TITLE
Allow passing a custom logger to the Client

### DIFF
--- a/aioambient/client.py
+++ b/aioambient/client.py
@@ -1,10 +1,13 @@
 """Define a client to interact with the Ambient Weather APIs."""
+import logging
 from typing import Optional
 
 from aiohttp import ClientSession
 
 from .api import API
 from .websocket import Websocket
+
+_LOGGER = logging.getLogger(__package__)
 
 DEFAULT_API_VERSION = 1
 
@@ -19,7 +22,11 @@ class Client:  # pylint: disable=too-few-public-methods
         *,
         api_version: int = DEFAULT_API_VERSION,
         session: Optional[ClientSession] = None,
+        logger: Optional[logging.Logger] = None,
     ) -> None:
         """Initialize."""
-        self.api = API(application_key, api_key, api_version, session)
-        self.websocket = Websocket(application_key, api_key, api_version)
+        if not logger:
+            logger = _LOGGER
+
+        self.api = API(logger, application_key, api_key, api_version, session=session)
+        self.websocket = Websocket(logger, application_key, api_key, api_version)

--- a/aioambient/const.py
+++ b/aioambient/const.py
@@ -1,4 +1,0 @@
-"""Define package constants."""
-import logging
-
-LOGGER = logging.getLogger(__package__)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,10 +50,9 @@ async def test_custom_logger(aresponses, caplog):
             TEST_API_KEY, TEST_APP_KEY, session=session, logger=custom_logger
         )
 
-        device_details = await client.api.get_device_details(
+        await client.api.get_device_details(
             TEST_MAC, end_date=datetime.date(2019, 1, 6)
         )
-        assert len(device_details) == 2
         assert any(
             record.name == "custom" and "Received data" in record.message
             for record in caplog.records

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,5 +1,7 @@
 """Define tests for the Websocket API."""
 # pylint: disable=protected-access
+import logging
+
 import aiohttp
 import pytest
 from socketio.exceptions import SocketIOError
@@ -171,7 +173,7 @@ async def test_watchdog_firing():
     mock_coro = AsyncMock()
     mock_coro.__name__ = "mock_coro"
 
-    watchdog = WebsocketWatchdog(mock_coro)
+    watchdog = WebsocketWatchdog(logging.getLogger(), mock_coro)
 
     await watchdog.on_expire()
     mock_coro.assert_called_once()


### PR DESCRIPTION
**Describe what the PR does:**

`python-socketio` and `python-engineio` produce their own log messages, which can be confusing when someone is trying to view logs for this application. Since these packages allow for the inclusion of a custom logger, we should do the same so that logs can flow through. This PR accomplishes that.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.