### PR TITLE
Update REST and websocket APIs to new Ambient Weather endpoints

### DIFF
--- a/aioambient/api.py
+++ b/aioambient/api.py
@@ -10,7 +10,7 @@ from aiohttp.client_exceptions import ClientError
 from .const import DEFAULT_API_VERSION, LOGGER
 from .errors import RequestError
 
-REST_API_BASE = "https://api.ambientweather.net"
+REST_API_BASE = "https://rt.ambientweather.net"
 
 DEFAULT_LIMIT = 288
 DEFAULT_TIMEOUT = 10

--- a/aioambient/websocket.py
+++ b/aioambient/websocket.py
@@ -12,7 +12,7 @@ from .errors import WebsocketError
 
 DEFAULT_WATCHDOG_TIMEOUT = 900
 
-WEBSOCKET_API_BASE = "https://api.ambientweather.net"
+WEBSOCKET_API_BASE = "https://rt2.ambientweather.net"
 
 
 class WebsocketWatchdog:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,7 @@ from .common import TEST_API_KEY, TEST_APP_KEY, TEST_MAC, load_fixture
 async def test_api_error(aresponses):
     """Test the REST API raising an exception upon HTTP error."""
     aresponses.add(
-        "api.ambientweather.net",
+        "rt.ambientweather.net",
         "/v1/devices",
         "get",
         aresponses.Response(text="", status=500),
@@ -35,7 +35,7 @@ async def test_custom_logger(aresponses, caplog):
     custom_logger = logging.getLogger("custom")
 
     aresponses.add(
-        "api.ambientweather.net",
+        "rt.ambientweather.net",
         f"/v1/devices/{TEST_MAC}",
         "get",
         aresponses.Response(
@@ -59,7 +59,7 @@ async def test_custom_logger(aresponses, caplog):
 async def test_get_device_details(aresponses):
     """Test retrieving device details from the REST API."""
     aresponses.add(
-        "api.ambientweather.net",
+        "rt.ambientweather.net",
         f"/v1/devices/{TEST_MAC}",
         "get",
         aresponses.Response(
@@ -82,7 +82,7 @@ async def test_get_device_details(aresponses):
 async def test_get_devices(aresponses):
     """Test retrieving devices from the REST API."""
     aresponses.add(
-        "api.ambientweather.net",
+        "rt.ambientweather.net",
         "/v1/devices",
         "get",
         aresponses.Response(
@@ -103,7 +103,7 @@ async def test_get_devices(aresponses):
 async def test_session_from_scratch(aresponses):
     """Test that an aiohttp ClientSession is created on the fly if needed."""
     aresponses.add(
-        "api.ambientweather.net",
+        "rt.ambientweather.net",
         "/v1/devices",
         "get",
         aresponses.Response(

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -26,7 +26,7 @@ async def test_connect_async_success():
 
     await websocket.connect()
     websocket._sio.connect.assert_called_once_with(
-        f"https://api.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
+        f"https://rt2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
         transports=["websocket"],
     )
 
@@ -47,7 +47,7 @@ async def test_connect_sync_success():
 
     await websocket.connect()
     websocket._sio.connect.assert_called_once_with(
-        f"https://api.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
+        f"https://rt2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
         transports=["websocket"],
     )
 
@@ -86,7 +86,7 @@ async def test_data_async():
 
     await websocket.connect()
     websocket._sio.connect.assert_called_once_with(
-        f"https://api.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
+        f"https://rt2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
         transports=["websocket"],
     )
 
@@ -126,7 +126,7 @@ async def test_data_sync():
 
     await websocket.connect()
     websocket._sio.connect.assert_called_once_with(
-        f"https://api.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
+        f"https://rt2.ambientweather.net/?api=1&applicationKey={TEST_APP_KEY}",
         transports=["websocket"],
     )
 


### PR DESCRIPTION
**Describe what the PR does:**

Per [a recommendation from the Ambient Weather devs](https://github.com/ambient-weather/api-docs/issues/30#issuecomment-954950244), this PR updates the endpoints used for both REST and websocket APIs.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
