### PR TITLE
Add utility to get a public device ID

### DIFF
--- a/aioambient/util/__init__.py
+++ b/aioambient/util/__init__.py
@@ -1,0 +1,10 @@
+"""Define package utilities."""
+from hashlib import md5
+
+
+def get_public_device_id(mac_address: str) -> str:
+    """Get the public device ID (if it exists) of a device by MAC address."""
+    public_id = mac_address
+    for _ in range(2):
+        public_id = md5(public_id.encode("utf-8")).hexdigest()
+    return public_id

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,11 @@
+"""Define tests for utilities."""
+import pytest
+
+from aioambient.util import get_public_device_id
+
+
+@pytest.mark.asyncio
+async def test_get_public_id():
+    """Test getting the public ID of a device by its MAC address."""
+    public_id = get_public_device_id("AB:CD:EF:12:34:56")
+    assert public_id == "04629a94fef5bfb62b525a6784cb8b37"


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the ability to calculate the public device ID for a MAC address (which is how Ambient structures public dashboard URLs, like `https://ambientweather.net/dashboard/<ID>`.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
