### PR TITLE
Ensure Python 3.7 is the minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 aiohttp = ">=3.8.0"
-python = "^3.6.1"
+python = ">=3.7.0"
 python-engineio = ">=3.13.1,<5.0.0"
 python-socketio = ">=4.6,<6.0"
 websockets = ">=9.1,<11.0"


### PR DESCRIPTION
**Describe what the PR does:**

We weren't properly enforcing what we already represent: Python 3.7 is the minimum. This PR enforces it.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
