### PR TITLE
Update CI to use GA release of Python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0"
+          - "3.11"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-rc.2"
+          - "3.11.0"
 
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
           - --configfile=.bandit.yaml
         files: ^aioambient/.+\.py$
   - repo: https://github.com/python/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
         args:
@@ -19,7 +19,7 @@ repos:
         language_version: python3
         files: ^((aioambient|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.2
     hooks:
       - id: codespell
         args:
@@ -27,7 +27,7 @@ repos:
           - --quiet-level=4
         exclude_types: [json]
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:
@@ -43,7 +43,7 @@ repos:
           - toml
         files: ^(aioambient|tests)/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v0.982
     hooks:
       - id: mypy
         files: ^aioambient/.+\.py$
@@ -69,6 +69,6 @@ repos:
       - id: shellcheck
         files: ^script/.+
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.1
+    rev: v3.1.0
     hooks:
       - id: pyupgrade

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ pip install aioambient
 
 `aioambient` is currently supported on:
 
-* Python 3.7
-* Python 3.8
 * Python 3.9
 * Python 3.10
 * Python 3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ disallow_untyped_defs = true
 follow_imports = "silent"
 ignore_missing_imports = true
 no_implicit_optional = true
-python_version = "3.8"
+python_version = "3.10"
 show_error_codes = true
 strict_equality = true
 warn_incomplete_stub = true
@@ -56,8 +56,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -67,7 +65,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 aiohttp = ">=3.8.0"
-python = ">=3.7.0"
+python = ">=3.9.0"
 python-engineio = ">=3.13.1,<5.0.0"
 python-socketio = ">=4.6,<6.0"
 websockets = ">=9.1,<11.0"


### PR DESCRIPTION
**Describe what the PR does:**

Happy Python 3.11 release day! This PR updates CI to tests against the GA release. Per our standards of supporting the three most recent versions, this PR also removes official support for anything before 3.9.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
