### PR TITLE
Replace U+2013 "–" with ASCII character U+002d "-"

### DIFF
--- a/aioambient/websocket.py
+++ b/aioambient/websocket.py
@@ -49,12 +49,12 @@ class WebsocketWatchdog:
 
     async def on_expire(self) -> None:
         """Log and act when the watchdog expires."""
-        self._logger.info("Watchdog expired – calling %s", self._action.__name__)
+        self._logger.info("Watchdog expired - calling %s", self._action.__name__)
         await self._action()
 
     async def trigger(self) -> None:
         """Trigger the watchdog."""
-        self._logger.info("Watchdog triggered – sleeping for %s seconds", self._timeout)
+        self._logger.info("Watchdog triggered - sleeping for %s seconds", self._timeout)
 
         if self._timer_task:
             self._timer_task.cancel()


### PR DESCRIPTION
**Describe what the PR does:**
The character U+2013 "–" could be confused with the ASCII character U+002d "-", which is more common in source code.

**Does this fix a specific issue?**
VSCode complains about Unicode characters in HA log files.
<img width="700" alt="image" src="https://github.com/bachya/aioambient/assets/2061579/e90868dd-2e28-4167-bcaa-0007e0701242">

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.

Small PR, no functional changes.