### PR TITLE
ci: renovate use of `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,11 +85,6 @@ repos:
         language: system
         types: [python]
         entry: poetry run ruff format
-      - id: isort
-        name: 🔀 Sorting all imports with isort
-        language: system
-        types: [python]
-        entry: poetry run isort
       - id: mypy
         name: 🆎 Performing static type checking using mypy
         language: system
@@ -115,17 +110,11 @@ repos:
         language: system
         types: [python]
         entry: poetry run pylint
-      - id: pyupgrade
-        name: 🆙 Checking for upgradable syntax with pyupgrade
-        language: system
-        types: [python]
-        entry: poetry run pyupgrade
-        args: [--py39-plus, --keep-runtime-typing]
       - id: ruff
         name: 👔 Enforcing style guide with ruff
         language: system
         types: [python]
-        entry: poetry run ruff --fix
+        entry: poetry run ruff check --fix
       - id: trailing-whitespace
         name: ✄  Trimming trailing whitespace
         language: system
@@ -139,11 +128,6 @@ repos:
         entry: poetry run vulture
         pass_filenames: false
         require_serial: true
-      - id: yamllint
-        name: 🎗  Checking YAML files with yamllint
-        language: system
-        types: [yaml]
-        entry: poetry run yamllint
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.0-alpha.4"

--- a/aioambient/__init__.py
+++ b/aioambient/__init__.py
@@ -1,5 +1,11 @@
 """Define module exports."""
 
-from .api import API  # noqa
-from .open_api import OpenAPI  # noqa
-from .websocket import Websocket  # noqa
+from .api import API
+from .open_api import OpenAPI
+from .websocket import Websocket
+
+__all__ = [
+    "API",
+    "OpenAPI",
+    "Websocket",
+]

--- a/aioambient/api.py
+++ b/aioambient/api.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import date
+import logging
 from typing import Any, cast
 
 from aiohttp import ClientSession
@@ -19,7 +19,7 @@ DEFAULT_LIMIT = 288
 class API(ApiRequestHandler):
     """Define the API object."""
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         application_key: str | None,
         api_key: str | None,
@@ -31,11 +31,13 @@ class API(ApiRequestHandler):
         """Initialize.
 
         Args:
+        ----
             application_key: An Ambient Weather application key.
             api_key: An Ambient Weather API key.
             api_version: The version of the API to query.
             logger: The logger to use.
             session: An optional aiohttp ClientSession.
+
         """
         super().__init__(
             f"{REST_API_BASE}/v{api_version}", logger=logger, session=session
@@ -46,8 +48,10 @@ class API(ApiRequestHandler):
     async def get_devices(self) -> list[dict[str, Any]]:
         """Get all devices associated with an API key.
 
-        Returns:
+        Returns
+        -------
             An API response payload.
+
         """
         params: dict[str, Any] = {
             "apiKey": self._api_key,
@@ -69,12 +73,15 @@ class API(ApiRequestHandler):
         """Get details of a device by MAC address.
 
         Args:
+        ----
             mac_address: The MAC address of an Ambient Weather station.
             end_date: An optional end date to limit data.
             limit: An optional limit.
 
         Returns:
+        -------
             An API response payload.
+
         """
         params: dict[str, Any] = {
             "apiKey": self._api_key,

--- a/aioambient/api_request_handler.py
+++ b/aioambient/api_request_handler.py
@@ -15,15 +15,17 @@ from .errors import RequestError
 DEFAULT_TIMEOUT = 10
 
 
-# Request returns either a list of dicts or a dict itself.
 RequestResponseT = list[dict[str, Any]] | dict[str, Any]
 
 
 class ApiRequestHandler:  # pylint: disable=too-few-public-methods
-    """Handle API requests. Base class for both the API and OpenAPI classes.
-    Handles all requests to Ambient services."""
+    """Handle API requests.
 
-    def __init__(  # pylint: disable=too-many-arguments
+    Base class for both the API and OpenAPI classes. Handles all requests to Ambient
+    services.
+    """
+
+    def __init__(
         self,
         base_url: str,
         *,
@@ -33,9 +35,11 @@ class ApiRequestHandler:  # pylint: disable=too-few-public-methods
         """Initialize.
 
         Args:
+        ----
             base_url: Base URL for each request
             logger: The logger to use.
             session: An optional aiohttp ClientSession.
+
         """
         self._logger = logger
         self._session: ClientSession | None = session
@@ -51,15 +55,19 @@ class ApiRequestHandler:  # pylint: disable=too-few-public-methods
         https://ambientweather.docs.apiary.io/#introduction/rate-limiting
 
         Args:
+        ----
             method: An HTTP method.
             endpoint: A relative API endpoint.
             **kwargs: Additional kwargs to send with the request.
 
         Returns:
+        -------
             An API response payload.
 
         Raises:
+        ------
             RequestError: Raised upon an underlying HTTP error.
+
         """
         await asyncio.sleep(1)
 
@@ -75,7 +83,8 @@ class ApiRequestHandler:  # pylint: disable=too-few-public-methods
                 resp.raise_for_status()
                 data: RequestResponseT = await resp.json()
         except ClientError as err:
-            raise RequestError(f"Error requesting data from {url}: {err}") from err
+            msg = f"Error requesting data from {url}: {err}"
+            raise RequestError(msg) from err
         finally:
             if not use_running_session:
                 await session.close()

--- a/aioambient/errors.py
+++ b/aioambient/errors.py
@@ -4,16 +4,10 @@
 class AmbientError(Exception):
     """Define a base error."""
 
-    pass
-
 
 class RequestError(AmbientError):
     """Define an error related to invalid requests."""
 
-    pass
-
 
 class WebsocketError(AmbientError):
     """Define an error related to generic websocket errors."""
-
-    pass

--- a/aioambient/open_api.py
+++ b/aioambient/open_api.py
@@ -19,7 +19,7 @@ REST_API_BASE = "https://lightning.ambientweather.net"
 class OpenAPI(ApiRequestHandler):
     """Define the OpenAPI object."""
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         *,
         logger: logging.Logger = LOGGER,
@@ -28,8 +28,10 @@ class OpenAPI(ApiRequestHandler):
         """Initialize.
 
         Args:
+        ----
             logger: The logger to use.
             session: An optional aiohttp ClientSession.
+
         """
         super().__init__(REST_API_BASE, logger=logger, session=session)
 
@@ -45,7 +47,9 @@ class OpenAPI(ApiRequestHandler):
         temperature to replicate the server-side logic of the private API.
 
         Arguments:
+        ---------
             data: Map of station data.
+
         """
 
         if (last_data := data.get("lastData")) is None:
@@ -66,16 +70,21 @@ class OpenAPI(ApiRequestHandler):
     async def get_devices_by_location(
         self, latitude: float, longitude: float, radius: float = 1.0
     ) -> list[dict[str, Any]]:
-        """Get all devices registered within an area of `radius`
-        miles from the center given by (`latitude`, `longitude`).
+        """Get all devices registered within an radius.
+
+        We calculate within `radius` miles from the center given by
+        (`latitude`, `longitude`).
 
         Args:
+        ----
             latitude: Latitude of center.
             longitude: Longigude of center.
             radius: Radius (in miles).
 
         Returns:
+        -------
             An API response payload.
+
         """
         lat1, long1 = LocationUtils.shift_location(
             latitude, longitude, -radius, -radius
@@ -104,10 +113,13 @@ class OpenAPI(ApiRequestHandler):
         """Get details of a device by MAC address.
 
         Args:
+        ----
             mac_address: The MAC address of an Ambient Weather station.
 
         Returns:
+        -------
             An API response payload.
+
         """
         # This endpoint returns a single data dict.
         response = cast(

--- a/aioambient/util/__init__.py
+++ b/aioambient/util/__init__.py
@@ -7,10 +7,13 @@ def get_public_device_id(mac_address: str) -> str:
     """Get the public device ID (if it exists) of a device by MAC address.
 
     Args:
+    ----
         mac_address: The MAC address of the device.
 
     Returns:
+    -------
         The public-facing device ID.
+
     """
     public_id = mac_address
     for _ in range(2):

--- a/aioambient/util/climate_utils.py
+++ b/aioambient/util/climate_utils.py
@@ -17,10 +17,13 @@ class ClimateUtils:
         """Convert celsius to fahrenheit.
 
         Args:
+        ----
             celsius: Temperature measured in Celsius.
 
         Returns:
+        -------
             Converted temperature measured in Fahrenheit.
+
         """
         return celsius * 9.0 / 5.0 + 32.0
 
@@ -29,10 +32,13 @@ class ClimateUtils:
         """Convert fahrenheit to celsius.
 
         Args:
+        ----
             fahrenheit: Temperature measured in Fahrenheit.
 
         Returns:
+        -------
             Converted temperature measured in Celsius.
+
         """
         return (fahrenheit - 32.0) * 5.0 / 9.0
 
@@ -41,10 +47,13 @@ class ClimateUtils:
         """Convert kilometer per hour to miles per hour.
 
         Args:
+        ----
             kph: Speed measured in kilometers per hour.
 
         Returns:
+        -------
             Converted speed measured in miles per hour.
+
         """
         return kph * 0.621371192
 
@@ -53,11 +62,14 @@ class ClimateUtils:
         """Calculate the dew point in Celsius.
 
         Args:
+        ----
             temp_celsius: Temperature measured in Celsius.
             humidity: Relative humidity measured in percent.
 
         Returns:
+        -------
             Calculated dew point measured in Celsius.
+
         """
 
         g = MAGNUS_A * temp_celsius / (MAGNUS_B + temp_celsius) + log(humidity / 100.0)
@@ -70,11 +82,14 @@ class ClimateUtils:
         """Calculate the dew point in Fahrenheit.
 
         Args:
+        ----
             temp_fahrenheit: Temperature measured in Fahrenheit.
             humidity: Relative humidity measured in percent.
 
         Returns:
+        -------
             Calculated dew point measured in Fahrenheit.
+
         """
 
         if temp_fahrenheit is None or humidity is None:
@@ -93,11 +108,14 @@ class ClimateUtils:
         """Calculate the wind chill temperature in Fahrenheit.
 
         Args:
+        ----
             temp_fahrenheit: Temperature measured in Fahrenheit.
-            wind_speed: Wind speed measured in miles per hour.
+            wind_speed_mph: Wind speed measured in miles per hour.
 
         Returns:
+        -------
             Calculated wind chill measured in Fahrenheit.
+
         """
 
         return cast(
@@ -113,11 +131,14 @@ class ClimateUtils:
         """Calculate the heat index temperature in Fahrenheit.
 
         Args:
+        ----
             temp_fahrenheit: Temperature measured in Fahrenheit.
             humidity: Relative humidity measured in percent.
 
         Returns:
+        -------
             Calculated heat index measured in Fahrenheit.
+
         """
 
         result = 0.5 * (
@@ -157,12 +178,15 @@ class ClimateUtils:
         """Calculate the feels like temperature in Fahrenheit.
 
         Args:
+        ----
             temp_fahrenheit: Temperature measured in Fahrenheit.
             humidity: Relative humidity measured in percent.
             wind_speed_mph: Wind speed measured in miles per hour.
 
         Returns:
+        -------
             Calculated feels like temperature measured in Fahrenheit.
+
         """
 
         if temp_fahrenheit is None or humidity is None or wind_speed_mph is None:
@@ -183,12 +207,15 @@ class ClimateUtils:
         """Calculate the feels like temperature in Celsius.
 
         Args:
+        ----
             temp_celsius: Temperature measured in Celsius.
             humidity: Relative humidity measured in percent.
             wind_speed_kph: Wind speed measured in kilometers per hour.
 
         Returns:
+        -------
             Calculated feels like temperature measured in Celsius.
+
         """
 
         if temp_celsius is None or humidity is None or wind_speed_kph is None:
@@ -197,7 +224,7 @@ class ClimateUtils:
         temp_fahrenheit = ClimateUtils.convert_celsius_to_fahrenheit(temp_celsius)
         wind_speed_mph = ClimateUtils.convert_kph_to_mph(wind_speed_kph)
         return ClimateUtils.convert_fahrenheit_to_celsius(
-            # Result cannot be None, so cast it to float to avoid the mypy error.
+            # Result cannot be None, so cast it to float to avoid the mypy error:
             cast(
                 float,
                 ClimateUtils.feels_like_fahrenheit(

--- a/aioambient/util/location_utils.py
+++ b/aioambient/util/location_utils.py
@@ -1,8 +1,9 @@
 """Location utility functions."""
 
+from __future__ import annotations
+
 import math
 
-# Radius of the Earth in miles
 EARTH_RADIUS = 3959.0
 
 
@@ -13,36 +14,41 @@ class LocationUtils:  # pylint: disable=too-few-public-methods
     def shift_location(
         latitude: float, longitude: float, latitude_delta: float, longitude_delta: float
     ) -> tuple[float, float]:
-        """Calculates a new (latitude, longitude) pair by shifting the location
-        given by (`latitude`, `longitude`) by (`latitude_delta`, `longitude_delta`).
+        """Calculate a new (latitude, longitude) pair.
+
+        We shift the location given by (`latitude`, `longitude`) by (`latitude_delta`,
+        `longitude_delta`).
 
         Args:
+        ----
             latitude: Latitude (in degrees).
             longitude: Longitude (in degrees).
             latitude_delta: Latitude delta (in miles).
             longitude_delta: Longitude delta (in miles).
 
         Returns:
+        -------
             New (latitude, longitude) pair.
+
         """
 
-        # Convert latitude and longitude from degrees to radians
+        # Convert latitude and longitude from degrees to radians:
         latitude_rad = math.radians(latitude)
         longitude_rad = math.radians(longitude)
 
-        # Calculate angular distance in radians
+        # Calculate angular distance in radians:
         angular_latitude_delta = latitude_delta / EARTH_RADIUS
         angular_longitude_delta = longitude_delta / EARTH_RADIUS
 
-        # Calculate new latitude
+        # Calculate new latitude:
         new_latitude_rad = latitude_rad + angular_latitude_delta
 
-        # Calculate new longitude
+        # Calculate new longitude:
         new_longitude_rad = longitude_rad + angular_longitude_delta / math.cos(
             latitude_rad
         )
 
-        # Convert new latitude and longitude from radians to degrees
+        # Convert new latitude and longitude from radians to degrees:
         new_latitude = math.degrees(new_latitude_rad)
         new_longitude = math.degrees(new_longitude_rad)
 

--- a/aioambient/websocket.py
+++ b/aioambient/websocket.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from collections.abc import Awaitable, Callable
+import logging
 from typing import Any
 
 from aiohttp.client_exceptions import ClientConnectionError
@@ -28,13 +28,15 @@ class WebsocketWatchdog:
         action: Callable[..., Awaitable],
         *,
         timeout_seconds: int = DEFAULT_WATCHDOG_TIMEOUT,
-    ):
+    ) -> None:
         """Initialize.
 
         Args:
+        ----
             logger: The logger to use.
             action: The coroutine function to call when the watchdog expires.
             timeout_seconds: The number of seconds before the watchdog times out.
+
         """
         self._action = action
         self._logger = logger
@@ -65,7 +67,7 @@ class WebsocketWatchdog:
         )
 
 
-class Websocket:  # pylint: disable=too-many-instance-attributes
+class Websocket:
     """Define the websocket."""
 
     def __init__(
@@ -79,10 +81,12 @@ class Websocket:  # pylint: disable=too-many-instance-attributes
         """Initialize.
 
         Args:
+        ----
             application_key: An Ambient Weather application key.
             api_key: An Ambient Weather API key.
             api_version: The version of the API to query.
             logger: The logger to use.
+
         """
         if isinstance(api_key, str):
             api_key = [api_key]
@@ -110,7 +114,9 @@ class Websocket:  # pylint: disable=too-many-instance-attributes
         """Define a coroutine to be called when connecting.
 
         Args:
+        ----
             target: The coroutine function to call upon websocket connect.
+
         """
         self._async_user_connect_handler = target
         self._user_connect_handler = None
@@ -119,7 +125,9 @@ class Websocket:  # pylint: disable=too-many-instance-attributes
         """Define a method to be called when connecting.
 
         Args:
+        ----
             target: The function to call upon websocket connect.
+
         """
         self._async_user_connect_handler = None
         self._user_connect_handler = target
@@ -130,14 +138,18 @@ class Websocket:  # pylint: disable=too-many-instance-attributes
         """Define a coroutine to be called when data is received.
 
         Args:
+        ----
             target: The coroutine function to call when receiving websocket data.
+
         """
 
         async def _async_on_data(data: dict[str, Any]) -> None:
             """Act on the data.
 
             Args:
+            ----
                 data: The websocket data received.
+
             """
             await self._watchdog.trigger()
             await target(data)
@@ -148,14 +160,18 @@ class Websocket:  # pylint: disable=too-many-instance-attributes
         """Define a method to be called when data is received.
 
         Args:
+        ----
             target: The function to call when receiving websocket data.
+
         """
 
         async def _async_on_data(data: dict[str, Any]) -> None:
             """Act on the data.
 
             Args:
+            ----
                 data: The websocket data received.
+
             """
             await self._watchdog.trigger()
             target(data)
@@ -166,7 +182,9 @@ class Websocket:  # pylint: disable=too-many-instance-attributes
         """Define a coroutine to be called when disconnecting.
 
         Args:
+        ----
             target: The coroutine function to call upon websocket connect.
+
         """
         self._sio.on("disconnect", target)
 
@@ -174,7 +192,9 @@ class Websocket:  # pylint: disable=too-many-instance-attributes
         """Define a method to be called when disconnecting.
 
         Args:
+        ----
             target: The function to call upon websocket connect.
+
         """
         self._sio.on("disconnect", target)
 
@@ -184,14 +204,18 @@ class Websocket:  # pylint: disable=too-many-instance-attributes
         """Define a coroutine to be called when subscribed.
 
         Args:
+        ----
             target: The coroutine function to call when receiving websocket data.
+
         """
 
         async def _async_on_subscribed(data: dict[str, Any]) -> None:
             """Act on subscribe.
 
             Args:
+            ----
                 data: The websocket data received.
+
             """
             await self._watchdog.trigger()
             await target(data)
@@ -202,14 +226,18 @@ class Websocket:  # pylint: disable=too-many-instance-attributes
         """Define a method to be called when subscribed.
 
         Args:
+        ----
             target: The function to call when receiving websocket data.
+
         """
 
         async def _async_on_subscribed(data: dict[str, Any]) -> None:
             """Act on subscribe.
 
             Args:
+            ----
                 data: The websocket data received.
+
             """
             await self._watchdog.trigger()
             target(data)
@@ -219,8 +247,10 @@ class Websocket:  # pylint: disable=too-many-instance-attributes
     async def connect(self) -> None:
         """Connect to the socket.
 
-        Raises:
+        Raises
+        ------
             WebsocketError: Raised upon any issue with the websocket.
+
         """
         try:
             self._sio.on("connect", self._init_connection)

--- a/examples/test_rest_api.py
+++ b/examples/test_rest_api.py
@@ -28,8 +28,8 @@ async def main() -> None:
                 details = await api.get_device_details(device["macAddress"])
                 _LOGGER.info("Device Details (%s): %s", device["macAddress"], details)
 
-        except AmbientError as err:
-            _LOGGER.error("There was an error: %s", err)
+        except AmbientError:
+            _LOGGER.exception("There was an error")
 
 
 asyncio.run(main())

--- a/examples/test_websocket.py
+++ b/examples/test_websocket.py
@@ -19,7 +19,9 @@ def print_data(data: dict[str, Any]) -> None:
     """Print data as it is received.
 
     Args:
+    ----
         data: The websocket data received.
+
     """
     _LOGGER.info("Data received: %s", data)
 
@@ -38,7 +40,9 @@ def print_subscribed(data: dict[str, Any]) -> None:
     """Print subscription data as it is received.
 
     Args:
+    ----
         data: The websocket data received.
+
     """
     _LOGGER.info("Client has subscribed: %s", data)
 
@@ -56,8 +60,8 @@ async def main() -> None:
 
     try:
         await websocket.connect()
-    except WebsocketError as err:
-        _LOGGER.error("There was a websocket error: %s", err)
+    except WebsocketError:
+        _LOGGER.exception("There was a websocket error")
         return
 
     while True:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ yamllint = "^1.28.0"
 Changelog = "https://github.com/bachya/aioambient/releases"
 
 [tool.pylint.BASIC]
+class-const-naming-style = "any"
 expected-line-ending-format = "LF"
 
 [tool.pylint.DESIGN]
@@ -105,45 +106,312 @@ max-attributes = 20
 [tool.pylint.FORMAT]
 max-line-length = 88
 
-[tool.pylint.MASTER]
-extension-pkg-whitelist = [
-  "pydantic",
-]
+[tool.pylint.MAIN]
+py-version = "3.12"
 ignore = [
-  "tests",
+    "tests",
 ]
+# Use a conservative default here; 2 should speed up most setups and not hurt
+# any too bad. Override on command line as appropriate.
+jobs = 2
+init-hook = """\
+    from pathlib import Path; \
+    import sys; \
+
+    from pylint.config import find_default_config_files; \
+
+    sys.path.append( \
+        str(Path(next(find_default_config_files())).parent.joinpath('pylint/plugins'))
+    ) \
+    """
 load-plugins = [
-  "pylint.extensions.bad_builtin",
-  "pylint.extensions.code_style",
-  "pylint.extensions.docparams",
-  "pylint.extensions.docstyle",
-  "pylint.extensions.empty_comment",
-  "pylint.extensions.overlapping_exceptions",
-  "pylint.extensions.typing",
+    "pylint.extensions.code_style",
+    "pylint.extensions.typing",
+]
+persistent = false
+fail-on = [
+    "I",
 ]
 
 [tool.pylint."MESSAGES CONTROL"]
-# Reasons disabled:
-# unnecessary-pass - This can hurt readability
 disable = [
-  "unnecessary-pass"
+    # These are subjective and should be left up to the developer:
+    "too-many-arguments",
+    "too-many-lines",
+    "too-many-locals",
+    "duplicate-code",
+
+    # Handled by ruff:
+    # Ref: <https://github.com/astral-sh/ruff/issues/970>
+    "anomalous-backslash-in-string",        # W605
+    "assert-on-string-literal",             # PLW0129
+    "assert-on-tuple",                      # F631
+    "await-outside-async",                  # PLE1142
+    "bad-classmethod-argument",             # N804
+    "bad-format-string",                    # W1302, F
+    "bad-format-string-key",                # W1300, F
+    "bad-str-strip-call",                   # PLE1310
+    "bad-string-format-type",               # PLE1307
+    "bare-except",                          # E722
+    "bidirectional-unicode",                # PLE2502
+    "binary-op-exception",                  # PLW0711
+    "broad-exception-caught",               # W0718
+    "cell-var-from-loop",                   # B023
+    "comparison-of-constants",              # PLR0133
+    "comparison-with-itself",               # PLR0124
+    "consider-alternative-union-syntax",    # UP007
+    "consider-iterating-dictionary",        # SIM118
+    "consider-merging-isinstance",          # PLR1701
+    "consider-using-alias",                 # UP006
+    "consider-using-dict-comprehension",    # C402
+    "consider-using-generator",             # C417
+    "consider-using-get",                   # SIM401
+    "consider-using-set-comprehension",     # C401
+    "consider-using-sys-exit",              # PLR1722
+    "consider-using-ternary",               # SIM108
+    "continue-in-finally",                  # PLE0116
+    "duplicate-bases",                      # PLE0241
+    "duplicate-except",                     # B014
+    "duplicate-key",                        # F601
+    "duplicate-string-formatting-argument", # F
+    "duplicate-value",                      # F
+    "empty-docstring",                      # D419
+    "eval-used",                            # S307
+    "exec-used",                            # S102
+    "expression-not-assigned",              # B018
+    "f-string-without-interpolation",       # F541
+    "forgotten-debug-statement",            # T100
+    "format-needs-mapping",                 # F502
+    "format-string-without-interpolation",  # F
+    "function-redefined",                   # F811
+    "global-variable-not-assigned",         # PLW0602
+    "implicit-str-concat",                  # ISC001
+    "import-self",                          # PLW0406
+    "inconsistent-quotes",                  # Q000
+    "invalid-all-object",                   # PLE0604
+    "invalid-character-backspace",          # PLE2510
+    "invalid-character-esc",                # PLE2513
+    "invalid-character-nul",                # PLE2514
+    "invalid-character-sub",                # PLE2512
+    "invalid-character-zero-width-space",   # PLE2515
+    "invalid-envvar-default",               # PLW1508
+    "invalid-name",                         # N815
+    "keyword-arg-before-vararg",            # B026
+    "line-too-long",                        # E501
+    "literal-comparison",                   # F632
+    "logging-format-interpolation",         # G
+    "logging-fstring-interpolation",        # G
+    "logging-not-lazy",                     # G
+    "logging-too-few-args",                 # PLE1206
+    "logging-too-many-args",                # PLE1205
+    "misplaced-future",                     # F404
+    "missing-class-docstring",              # D101
+    "missing-final-newline",                # W292
+    "missing-format-string-key",            # F524
+    "missing-function-docstring",           # D103
+    "missing-module-docstring",             # D100
+    "mixed-format-string",                  # F506
+    "multiple-imports",                     #E401
+    "named-expr-without-context",           # PLW0131
+    "nested-min-max",                       # PLW3301
+    "no-method-argument",                   # N805
+    "no-self-argument",                     # N805
+    "nonexistent-operator",                 # B002
+    "nonlocal-without-binding",             # PLE0117
+    "not-in-loop",                          # F701, F702
+    "notimplemented-raised",                # F901
+    "pointless-statement",                  # B018
+    "property-with-parameters",             # PLR0206
+    "raise-missing-from",                   # B904
+    "return-in-init",                       # PLE0101
+    "return-outside-function",              # F706
+    "singleton-comparison",                 # E711, E712
+    "subprocess-run-check",                 # PLW1510
+    "super-with-arguments",                 # UP008
+    "superfluous-parens",                   # UP034
+    "syntax-error",                         # E999
+    "too-few-format-args",                  # F524
+    "too-many-branches",                    # PLR0912
+    "too-many-format-args",                 # F522
+    "too-many-return-statements",           # PLR0911
+    "too-many-star-expressions",            # F622
+    "too-many-statements",                  # PLR0915
+    "trailing-comma-tuple",                 # COM818
+    "truncated-format-string",              # F501
+    "try-except-raise",                     # TRY302
+    "undefined-all-variable",               # F822
+    "undefined-variable",                   # F821
+    "ungrouped-imports",                    # I001
+    "unidiomatic-typecheck",                # E721
+    "unnecessary-comprehension",            # C416
+    "unnecessary-direct-lambda-call",       # PLC3002
+    "unnecessary-lambda-assignment",        # PLC3001
+    "unnecessary-pass",                     # PIE790
+    "unneeded-not",                         # SIM208
+    "unused-argument",                      # ARG001
+    "unused-format-string-argument",        # F507
+    "unused-format-string-key",             # F504
+    "unused-import",                        # F401
+    "unused-variable",                      # F841
+    "use-a-generator",                      # C417
+    "use-dict-literal",                     # C406
+    "use-list-literal",                     # C405
+    "used-prior-global-declaration",        # PLE0118
+    "useless-else-on-loop",                 # PLW0120
+    "useless-import-alias",                 # PLC0414
+    "useless-object-inheritance",           # UP004
+    "useless-return",                       # PLR1711
+    "wildcard-import",                      # F403
+    "wrong-import-order",                   # I001
+    "wrong-import-position",                # E402
+    "yield-inside-async-function",          # PLE1700
+    "yield-outside-function",               # F704
+
+    # Handled by mypy:
+    # Ref: <https://github.com/antonagestam/pylint-mypy-overlap>
+    "abstract-class-instantiated",
+    "arguments-differ",
+    "assigning-non-slot",
+    "assignment-from-no-return",
+    "assignment-from-none",
+    "bad-exception-cause",
+    "bad-format-character",
+    "bad-reversed-sequence",
+    "bad-super-call",
+    "bad-thread-instantiation",
+    "catching-non-exception",
+    "comparison-with-callable",
+    "deprecated-class",
+    "dict-iter-missing-items",
+    "format-combined-specification",
+    "global-variable-undefined",
+    "import-error",
+    "inconsistent-mro",
+    "inherit-non-class",
+    "init-is-generator",
+    "invalid-class-object",
+    "invalid-enum-extension",
+    "invalid-envvar-value",
+    "invalid-format-returned",
+    "invalid-hash-returned",
+    "invalid-metaclass",
+    "invalid-overridden-method",
+    "invalid-repr-returned",
+    "invalid-sequence-index",
+    "invalid-slice-index",
+    "invalid-slots",
+    "invalid-slots-object",
+    "invalid-star-assignment-target",
+    "invalid-str-returned",
+    "invalid-unary-operand-type",
+    "invalid-unicode-codec",
+    "isinstance-second-argument-not-valid-type",
+    "method-hidden",
+    "misplaced-format-function",
+    "missing-format-argument-key",
+    "missing-format-attribute",
+    "missing-kwoa",
+    "no-member",
+    "no-value-for-parameter",
+    "non-iterator-returned",
+    "non-str-assignment-to-dunder-name",
+    "nonlocal-and-global",
+    "not-a-mapping",
+    "not-an-iterable",
+    "not-async-context-manager",
+    "not-callable",
+    "not-context-manager",
+    "overridden-final-method",
+    "raising-bad-type",
+    "raising-non-exception",
+    "redundant-keyword-arg",
+    "relative-beyond-top-level",
+    "self-cls-assignment",
+    "signature-differs",
+    "star-needs-assignment-target",
+    "subclassed-final-class",
+    "super-without-brackets",
+    "too-many-function-args",
+    "typevar-double-variance",
+    "typevar-name-mismatch",
+    "unbalanced-dict-unpacking",
+    "unbalanced-tuple-unpacking",
+    "unexpected-keyword-arg",
+    "unhashable-member",
+    "unpacking-non-sequence",
+    "unsubscriptable-object",
+    "unsupported-assignment-operation",
+    "unsupported-binary-operation",
+    "unsupported-delete-operation",
+    "unsupported-membership-test",
+    "used-before-assignment",
+    "using-final-decorator-in-unsupported-version",
+    "wrong-exception-operation",
+]
+enable = [
+    "useless-suppression",
+    "use-symbolic-message-instead",
 ]
 
-[tool.pylint.REPORTS]
-score = false
+[tool.pylint.TYPING]
+runtime-typing = false
 
-[tool.pylint.SIMILARITIES]
-# Minimum lines number of a similarity.
-min-similarity-lines = 8
+[tool.pylint.CODE_STYLE]
+max-line-length-suggestions = 72
 
-# Ignore comments when computing similarities.
-ignore-comments = true
+[tool.ruff.lint]
+select = [
+    "ALL"
+]
 
-# Ignore docstrings when computing similarities.
-ignore-docstrings = true
+ignore = [
+    "ANN101",  # Missing type annotation for self
+    "D202",    # No blank lines allowed after function docstring
+    "D203",    # 1 blank line required before class docstring
+    "PLR0913", # This is subjective
+    "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
+    "PT012",   # `pytest.raises()` block should contain a single simple statement
+    "TCH",     # flake8-type-checking
 
-# Ignore imports when computing similarities.
-ignore-imports = true
+    # May conflict with the formatter:
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "COM812",
+    "COM819",
+    "D206",
+    "D300",
+    "E111",
+    "E114",
+    "E117",
+    "ISC001",
+    "ISC002",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "W191",
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = [
+    "aioambient",
+    "examples",
+    "tests",
+]
+combine-as-imports = true
+split-on-trailing-comma = false
+
+[tool.ruff.lint.per-file-ignores]
+"aioambient/util/climate_utils.py" = [
+    "PLR2004",  # Climate utils utilize a ton of inline constants
+]
+"tests/*" = [
+    "ARG001",   # Tests ofen have unused arguments
+    "FBT001",   # Test fixtures may be boolean values
+    "PLR2004",  # Checking for magic values in tests isn't helpful
+    "S101",     # Assertions are fine in tests
+    "SLF001",   # We'll access a lot of private third-party members in tests
+]
 
 [tool.vulture]
 min_confidence = 80

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,6 @@
 """Define common test utilities."""
 
-import os
+from pathlib import Path
 
 TEST_API_KEY = "12345abcde"
 TEST_APP_KEY = "12345abcde"
@@ -11,11 +11,14 @@ def load_fixture(filename: str) -> str:
     """Load a fixture.
 
     Args:
+    ----
         filename: The filename of the fixtures/ file to load.
 
     Returns:
+    -------
         A string containing the contents of the file.
+
     """
-    path = os.path.join(os.path.dirname(__file__), "fixtures", filename)
-    with open(path, encoding="utf-8") as fptr:
+    path = Path(f"{Path(__file__).parent}/fixtures/{filename}")
+    with Path.open(path, encoding="utf-8") as fptr:
         return fptr.read()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,8 +5,8 @@ import logging
 from unittest.mock import Mock
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aioambient import API
 from aioambient.errors import RequestError
@@ -14,12 +14,14 @@ from aioambient.errors import RequestError
 from .common import TEST_API_KEY, TEST_APP_KEY, TEST_MAC, load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_api_error(aresponses: ResponsesMockServer) -> None:
     """Test the REST API raising an exception upon HTTP error.
 
     Args:
+    ----
         aresponses: An aresponses server.
+
     """
     aresponses.add(
         "rt.ambientweather.net",
@@ -35,13 +37,15 @@ async def test_api_error(aresponses: ResponsesMockServer) -> None:
             await api.get_devices()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_custom_logger(aresponses: ResponsesMockServer, caplog: Mock) -> None:
     """Test that a custom logger is used when provided to the client.
 
     Args:
+    ----
         aresponses: An aresponses server.
         caplog: A mocked logging facility.
+
     """
     caplog.set_level(logging.DEBUG)
     custom_logger = logging.getLogger("custom")
@@ -67,12 +71,14 @@ async def test_custom_logger(aresponses: ResponsesMockServer, caplog: Mock) -> N
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_device_details(aresponses: ResponsesMockServer) -> None:
     """Test retrieving device details from the REST API.
 
     Args:
+    ----
         aresponses: An aresponses server.
+
     """
     aresponses.add(
         "rt.ambientweather.net",
@@ -94,12 +100,14 @@ async def test_get_device_details(aresponses: ResponsesMockServer) -> None:
         assert len(device_details) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_devices(aresponses: ResponsesMockServer) -> None:
     """Test retrieving devices from the REST API.
 
     Args:
+    ----
         aresponses: An aresponses server.
+
     """
     aresponses.add(
         "rt.ambientweather.net",
@@ -119,12 +127,14 @@ async def test_get_devices(aresponses: ResponsesMockServer) -> None:
         assert len(devices) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_session_from_scratch(aresponses: ResponsesMockServer) -> None:
     """Test that an aiohttp ClientSession is created on the fly if needed.
 
     Args:
+    ----
         aresponses: An aresponses server.
+
     """
     aresponses.add(
         "rt.ambientweather.net",

--- a/tests/test_open_api.py
+++ b/tests/test_open_api.py
@@ -3,20 +3,22 @@
 import re
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aioambient import OpenAPI
 
 from .common import TEST_MAC, load_fixture
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_device_details(aresponses: ResponsesMockServer) -> None:
     """Test retrieving device details from the open REST API.
 
     Args:
+    ----
         aresponses: An aresponses server.
+
     """
     aresponses.add(
         "lightning.ambientweather.net",
@@ -40,12 +42,14 @@ async def test_get_device_details(aresponses: ResponsesMockServer) -> None:
         assert device_details["lastData"]["feelsLike"] == 85.76260552070016
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_devices_by_location(aresponses: ResponsesMockServer) -> None:
     """Test retrieving devices from the open REST API.
 
     Args:
+    ----
         aresponses: An aresponses server.
+
     """
     aresponses.add(
         "lightning.ambientweather.net",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,14 +6,14 @@ from aioambient.util import get_public_device_id
 from aioambient.util.location_utils import LocationUtils
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_get_public_id() -> None:
     """Test getting the public ID of a device by its MAC address."""
     public_id = get_public_device_id("AB:CD:EF:12:34:56")
     assert public_id == "04629a94fef5bfb62b525a6784cb8b37"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_shift_location() -> None:
     """Test for shift_location utility function."""
     lat, long = LocationUtils.shift_location(0, 0, 1, 1)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -13,7 +13,7 @@ from aioambient.websocket import WebsocketWatchdog
 from tests.common import TEST_API_KEY, TEST_APP_KEY
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_connect_async_success() -> None:
     """Test connecting to the socket with an async handler."""
     websocket = Websocket(TEST_API_KEY, TEST_APP_KEY)
@@ -34,7 +34,7 @@ async def test_connect_async_success() -> None:
     async_on_connect.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_connect_sync_success() -> None:
     """Test connecting to the socket with a sync handler."""
     websocket = Websocket(TEST_API_KEY, TEST_APP_KEY)
@@ -55,7 +55,7 @@ async def test_connect_sync_success() -> None:
     async_on_connect.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_connect_failure() -> None:
     """Test connecting to the socket and an exception occurring."""
     websocket = Websocket(TEST_API_KEY, TEST_APP_KEY)
@@ -65,7 +65,7 @@ async def test_connect_failure() -> None:
         await websocket.connect()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_data_async() -> None:
     """Test data and subscription with async handlers."""
     websocket = Websocket(TEST_API_KEY, TEST_APP_KEY)
@@ -105,7 +105,7 @@ async def test_data_async() -> None:
     websocket._sio.disconnect.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_data_sync() -> None:
     """Test data and subscription with sync handlers."""
     websocket = Websocket(TEST_API_KEY, TEST_APP_KEY)
@@ -145,7 +145,7 @@ async def test_data_sync() -> None:
     websocket._sio.disconnect.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_reconnect() -> None:
     """Test that reconnecting to the websocket does the right thing."""
     websocket = Websocket(TEST_API_KEY, TEST_APP_KEY)
@@ -166,7 +166,7 @@ async def test_reconnect() -> None:
     async_on_connect.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_watchdog_firing() -> None:
     """Test that the watchdog expiring fires the provided coroutine."""
     mock_coro = AsyncMock()


### PR DESCRIPTION
**Describe what the PR does:**

This PR uses more of `ruff`'s ruleset, which allows us to (a) be more conforming across the board, (b) eliminate redundant `pylint` and `mypy` checks, and (c) remove several redundant `pre-commit` hooks.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
